### PR TITLE
chore: update to 6to5 v2.2

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -23,7 +23,7 @@ let config = {
     loaders: [
       {
         test: /\/src\/.*\.js$/,
-        loader: '6to5?modules=commonInterop&experimental=true',
+        loader: '6to5?modules=common&experimental=true',
       },
       {
         test: /\.scss$/,

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/spacetme/bemuse",
   "devDependencies": {
-    "6to5": "^1.15.0",
-    "6to5-loader": "^0.2.4",
+    "6to5": "^2.2.0",
+    "6to5-loader": "^1.0.0",
     "autoprefixer-loader": "^1.0.0",
     "body-parser": "^1.10.0",
     "browser-launcher": "^1.0.0",

--- a/src/cachier/index.js
+++ b/src/cachier/index.js
@@ -1,7 +1,8 @@
 
 export default new Cachier()
+export { Cachier }
 
-export function Cachier(databaseName) {
+function Cachier(databaseName) {
 
   var indexedDB = window.indexedDB || window.webkitIndexedDB ||
                   window.mozIndexedDB || window.OIndexedDB ||
@@ -124,4 +125,5 @@ export function Cachier(databaseName) {
   }
 
 }
+
 


### PR DESCRIPTION
This new version uses core-js (zloirock/core-js), which is smaller than
ES6-shim (they said, significantly smaller).

The `commonInterop` module formatter has been merged into `common`. It has
some problems about default exporting (6to5/6to5#356). That's why some specs
have also been fixed in this commit.
