### PR TITLE
feat(scintillator/animation): generate keyframes from xml

### DIFF
--- a/spec/scintillator/nodes/concerns/animation_spec.js
+++ b/spec/scintillator/nodes/concerns/animation_spec.js
@@ -1,0 +1,39 @@
+
+import { _parse, _attrs }
+  from '../../../../src/scintillator/nodes/concerns/animation'
+import $ from 'jquery'
+
+let $xml = xml => $($.parseXML(xml).documentElement)
+
+describe('Scintillator::Animation', function() {
+
+  describe('_attrs', function() {
+    it('lists all attributes of an element', function() {
+      let xml = $xml(`<keyframe t="0" x="10" y="30" />`)[0]
+      expect(_attrs(xml)).to.deep.equal({ t: '0', x: '10', y: '30' })
+    })
+  })
+
+  describe('_parse', function() {
+    it('compiles animation into keyframes', function() {
+      let xml = $xml(`<animation>
+        <keyframe t="0" x="10" y="30" />
+        <keyframe t="2" x="20" />
+        <keyframe t="5" x="15" y="20" />
+      </animation>`)
+      expect(_parse(xml)).to.deep.equal([
+        { name: 'x', keyframes: [
+            { time: 0, value: 10, ease: 'linear' },
+            { time: 2, value: 20, ease: 'linear' },
+            { time: 5, value: 15, ease: 'linear' },
+          ], },
+        { name: 'y', keyframes: [
+            { time: 0, value: 30, ease: 'linear' },
+            { time: 5, value: 20, ease: 'linear' },
+          ], },
+      ])
+    })
+  })
+
+})
+

--- a/src/scintillator/nodes/concerns/animation.js
+++ b/src/scintillator/nodes/concerns/animation.js
@@ -1,0 +1,32 @@
+
+import R from 'ramda'
+
+export class Animation {
+}
+
+export function _parse($el) {
+  let keyframes = R.map(_attrs, Array.from($el.children('keyframe')))
+  let attrs = { }
+  for (let keyframe of keyframes) {
+    let time = +keyframe.t
+    let ease = keyframe.ease || 'linear'
+    if (isNaN(time)) throw new Error('Expected keyframe to have "t" attribute')
+    for (let key in keyframe) {
+      if (key === 't' || key === 'ease') continue
+      let value = +keyframe[key]
+      let attr = attrs[key] || (attrs[key] = _createKeyframes(key))
+      attr.keyframes.push({ time, value, ease })
+    }
+  }
+  return R.values(attrs)
+}
+
+function _createKeyframes(name) {
+  return { name, keyframes: [] }
+}
+
+export function _attrs(el) {
+  return R.fromPairs(R.map(n => [n.name.toLowerCase(), n.value], el.attributes))
+}
+
+export default Animation


### PR DESCRIPTION
I found a library called "keytime" that does exactly what I need:
given a set of keyframes and the time, return the state of the animation.

An animation can work like this:

```jade
sprite(...)
  animation
    keyframe(t='0' x='-100')
    keyframe(t='1' x='0')
  animation(on='exitEvent')
    keyframe(t='0' x='0')
    keyframe(t='1' x='1000')
```

Here, there are two animations. The first one is the default animation, and the
second one is the "on exit" animation.

Which animation to use is selected based on latest event. An event is the
timestamp in the data passed to `render()` of the specified key.

    { t: 1.5, exitEvent: 1.2 }

This means the exitEvent has happened 0.3 seconds ago, so the exit animation
should be performed.