### PR TITLE
Support video in bmson

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "audio-context": "^0.1.0",
     "baconjs": "^0.7.75",
-    "bemuse-indexer": "^3.0.0",
+    "bemuse-indexer": "^3.1.0",
     "bemuse-notechart": "^1.0.11",
     "bluebird": "^3.3.4",
     "bms": "^2.0.0",

--- a/src/resources/bemuse-package.js
+++ b/src/resources/bemuse-package.js
@@ -1,11 +1,11 @@
+import * as ProgressUtils from 'bemuse/progress/utils'
 
-import { resolve }        from 'url'
 import addLazyProperty    from 'lazy-property'
 import download           from 'bemuse/utils/download'
 import readBlob           from 'bemuse/utils/read-blob'
 import throat             from 'throat'
 import Progress           from 'bemuse/progress'
-import * as ProgressUtils from 'bemuse/progress/utils'
+import { resolve }        from 'url'
 
 import { URLResource }    from './url'
 
@@ -78,6 +78,11 @@ class BemusePackageFileResource {
     return ProgressUtils.atomic(progress,
         this._resources.getBlob(this._ref)
         .then(blob => readBlob(blob).as('arraybuffer')))
+  }
+  resolveUrl () {
+    return this._resources.getBlob(this._ref).then(blob => (
+      URL.createObjectURL(blob)
+    ))
   }
   get name () {
     return this._name

--- a/src/resources/bemuse-package.spec.js
+++ b/src/resources/bemuse-package.spec.js
@@ -1,3 +1,4 @@
+import assert from 'power-assert'
 
 import BemusePackageResources from './bemuse-package'
 
@@ -21,6 +22,13 @@ describe('BemusePackageResources', function () {
       return expect(resources.file('mi.mp3')
         .then(file => file.read())
         .then(buffer => buffer.byteLength)).to.eventually.eq(30093)
+    })
+
+    it('can obtain url', function () {
+      return (resources.file('mi.mp3')
+        .then(file => file.resolveUrl())
+        .then(url => { assert(typeof url === 'string') })
+      )
     })
 
     it('cannot read if not bemuse file', function () {

--- a/src/resources/dnd-resources.js
+++ b/src/resources/dnd-resources.js
@@ -1,7 +1,7 @@
+import * as ProgressUtils from 'bemuse/progress/utils'
 
 import co from 'co'
 import readBlob from 'bemuse/utils/read-blob'
-import * as ProgressUtils from 'bemuse/progress/utils'
 
 export class DndResources {
   constructor (event) {
@@ -29,6 +29,9 @@ export class FileResource {
   read (progress) {
     return ProgressUtils.atomic(progress,
         readBlob(this._file).as('arraybuffer'))
+  }
+  resolveUrl () {
+    return Promise.resolve(URL.createObjectURL(this._file))
   }
   get name () {
     return this._file.name


### PR DESCRIPTION
This is due to `bemuse-indexer@3.1.0` adding `video_file` to the song object. Bemuse then takes the `video_file` and loads it from the song package.

__Note:__ If `video_url` exists, then it takes precedence.