### PR TITLE
Changed the pitch ratio of offbeat notes.

### DIFF
--- a/src/sampling-master/index.js
+++ b/src/sampling-master/index.js
@@ -226,8 +226,8 @@ class PlayInstance {
   bad () {
     if (!this._source) return
     this._source.playbackRate.value = (Math.random() < 0.5
-      ? Math.pow(2,  1 / 12)
-      : Math.pow(2, -1 / 12)
+      ? Math.pow(2,  1 / 24)
+      : Math.pow(2, -1 / 24)
     )
   }
 


### PR DESCRIPTION
I believe using a quarter tone is better than a semitone for an "off-pitch" feeling, because being a semitone off changes the note entirely rather than just detuning it.

I've playtested the sound with quarter tones off, and it's definitely noticeable and jarring, which is what I think the intended effect is for a note that's played off-beat.
