### PR TITLE
Use `cross-env` to allow Windows local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "index.js",
   "scripts": {
     "build": "gulp build",
-    "build:ios": "bash -c \"NODE_ENV=ios gulp build\"",
+    "build:ios": "cross-env NODE_ENV=ios gulp build",
     "ci:code-review": "npm run code-review; ./bin/upload-code-review",
     "code-review": "gulp code-review",
     "lint": "gulp lint",
     "pre-commit": "gulp pre-commit",
-    "start": "bash -c \"HOT=true gulp server\"",
-    "test": "bash -c \"NODE_ENV=test BEMUSE_COV=true gulp test\"",
-    "test-bed": "bash -c \"NODE_ENV=test test-bed\"",
+    "start": "cross-env HOT=true gulp server",
+    "test": "cross-env NODE_ENV=test BEMUSE_COV=true gulp test",
+    "test-bed": "cross-env NODE_ENV=test test-bed",
     "travis": "gulp travis"
   },
   "importSort": {
@@ -58,6 +58,7 @@
     "codecov": "^1.0.1",
     "connect": "^3.3.3",
     "coveralls": "^2.11.9",
+    "cross-env": "^5.0.5",
     "css-loader": "^0.27.1",
     "dotenv": "^2.0.0",
     "eslint": "^2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,11 +1802,26 @@ create-hmac@^1.1.0, create-hmac@^1.1.2:
     create-hash "^1.1.0"
     inherits "^2.0.1"
 
+cross-env@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -3969,6 +3984,10 @@ is-windows@^0.1.1:
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -6649,6 +6668,12 @@ shallow-clone@^0.1.2:
 shallow-copy@0.0.1, shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Following up on #438 and #440, I just realised that the npm tasks are hardcoded to work on a `bash` environment, which doesn't really exist on Windows (unless you run Cygwin/WSL).

`cross-env` provides a cross-platform solution to defining environment variables, so we'll attempt to use it here.