### PR TITLE
[React16] Attempt to convert `React.createClass()` to ES6 classes

### DIFF
--- a/bin/create-component
+++ b/bin/create-component
@@ -13,11 +13,11 @@ import './名.scss'
 import React from 'react'
 import c     from 'classnames'
 
-export default React.createClass({
+export default class extends React.Component{
   render() {
     return <div className="名"></div>
   }
-})
+}
 `.replace(/名/g, 名)
 
 let scssData = `

--- a/src/app/ui/AboutScene.jsx
+++ b/src/app/ui/AboutScene.jsx
@@ -160,7 +160,7 @@ class AboutScene extends React.Component {
         </article>
       </section>
       <SceneToolbar>
-        <a onClick={this.handleBack} href="javascript://">Back</a>
+        <a onClick={() => this.handleBack()} href="javascript://">Back</a>
       </SceneToolbar>
     </Scene>
   }

--- a/src/app/ui/AboutScene.jsx
+++ b/src/app/ui/AboutScene.jsx
@@ -160,7 +160,7 @@ class AboutScene extends React.Component {
         </article>
       </section>
       <SceneToolbar>
-        <a onClick={() => this.handleBack()} href="javascript://">Back</a>
+        <a onClick={this.handleBack} href="javascript://">Back</a>
       </SceneToolbar>
     </Scene>
   }
@@ -174,7 +174,7 @@ class AboutScene extends React.Component {
     })
   }
 
-  handleBack () {
+  handleBack = () => {
     SCENE_MANAGER.pop().done()
   }
 }

--- a/src/app/ui/AboutScene.jsx
+++ b/src/app/ui/AboutScene.jsx
@@ -13,11 +13,7 @@ let artists
 class AboutScene extends React.Component {
   constructor () {
     super()
-    this.state = this.getInitialState()
-  }
-
-  getInitialState () {
-    return { artists: [] }
+    this.state = { artists: [] }
   }
 
   componentDidMount () {

--- a/src/app/ui/AboutScene.jsx
+++ b/src/app/ui/AboutScene.jsx
@@ -10,16 +10,23 @@ import SCENE_MANAGER    from 'bemuse/scene-manager'
 
 let artists
 
-export default React.createClass({
+class AboutScene extends React.Component {
+  constructor () {
+    super()
+    this.state = this.getInitialState()
+  }
+
   getInitialState () {
     return { artists: [] }
-  },
+  }
+
   componentDidMount () {
     if (!artists) {
       artists = Promise.resolve($.get('/music/artists.json'))
     }
     artists.then(a => this.setState({ artists: a }))
-  },
+  }
+
   render () {
     return <Scene className="AboutScene">
       <SceneHeading>
@@ -160,7 +167,8 @@ export default React.createClass({
         <a onClick={this.handleBack} href="javascript://">Back</a>
       </SceneToolbar>
     </Scene>
-  },
+  }
+
   renderArtists () {
     if (this.state.artists.length === 0) {
       return <span>loading...</span>
@@ -168,8 +176,11 @@ export default React.createClass({
     return this.state.artists.map((artist, index) => {
       return [index ? ', ' : '', <a href={artist.url}>{artist.name}</a>]
     })
-  },
+  }
+
   handleBack () {
     SCENE_MANAGER.pop().done()
-  },
-})
+  }
+}
+
+export default AboutScene

--- a/src/app/ui/BrowserSupportWarningScene.jsx
+++ b/src/app/ui/BrowserSupportWarningScene.jsx
@@ -27,7 +27,7 @@ class BrowserSupportWarningScene extends React.Component {
         ])}.
       </p>
       <p>
-        <OptionsButton onClick={this.handleContinue}>
+        <OptionsButton onClick={() => this.handleContinue()}>
           Continue Anyway
         </OptionsButton>
       </p>

--- a/src/app/ui/BrowserSupportWarningScene.jsx
+++ b/src/app/ui/BrowserSupportWarningScene.jsx
@@ -7,7 +7,11 @@ import OptionsButton from './OptionsButton'
 import { SUPPORTED } from '../browser-support'
 import SCENE_MANAGER from 'bemuse/scene-manager'
 
-export default React.createClass({
+class BrowserSupportWarningScene extends React.Component {
+  constructor () {
+    super()
+  }
+
   render () {
     return <Scene className="BrowserSupportWarningScene">
       <h1>Warning: Unsupported Browser</h1>
@@ -31,8 +35,11 @@ export default React.createClass({
         <strong>User agent:</strong> {navigator.userAgent}
       </p>
     </Scene>
-  },
+  }
+
   handleContinue () {
     SCENE_MANAGER.display(this.props.next)
-  },
-})
+  }
+}
+
+export default BrowserSupportWarningScene

--- a/src/app/ui/BrowserSupportWarningScene.jsx
+++ b/src/app/ui/BrowserSupportWarningScene.jsx
@@ -27,7 +27,7 @@ class BrowserSupportWarningScene extends React.Component {
         ])}.
       </p>
       <p>
-        <OptionsButton onClick={() => this.handleContinue()}>
+        <OptionsButton onClick={this.handleContinue}>
           Continue Anyway
         </OptionsButton>
       </p>
@@ -37,7 +37,7 @@ class BrowserSupportWarningScene extends React.Component {
     </Scene>
   }
 
-  handleContinue () {
+  handleContinue = () => {
     SCENE_MANAGER.display(this.props.next)
   }
 }

--- a/src/app/ui/BrowserSupportWarningScene.jsx
+++ b/src/app/ui/BrowserSupportWarningScene.jsx
@@ -8,9 +8,6 @@ import { SUPPORTED } from '../browser-support'
 import SCENE_MANAGER from 'bemuse/scene-manager'
 
 class BrowserSupportWarningScene extends React.Component {
-  constructor () {
-    super()
-  }
 
   render () {
     return <Scene className="BrowserSupportWarningScene">

--- a/src/app/ui/ChangelogPanel.jsx
+++ b/src/app/ui/ChangelogPanel.jsx
@@ -9,11 +9,7 @@ import Markdown from 'bemuse/ui/Markdown'
 class ChangelogPanel extends React.Component {
   constructor () {
     super()
-    this.state = this.getInitialState()
-  }
-
-  getInitialState () {
-    return { data: { status: 'loading' } }
+    this.state = { data: { status: 'loading' } }
   }
 
   componentDidMount () {

--- a/src/app/ui/ChangelogPanel.jsx
+++ b/src/app/ui/ChangelogPanel.jsx
@@ -6,17 +6,24 @@ import _        from 'lodash'
 import Panel    from 'bemuse/ui/Panel'
 import Markdown from 'bemuse/ui/Markdown'
 
-export const ChangelogPanel = React.createClass({
+class ChangelogPanel extends React.Component {
+  constructor () {
+    super()
+    this.state = this.getInitialState()
+  }
+
   getInitialState () {
     return { data: { status: 'loading' } }
-  },
+  }
+
   componentDidMount () {
     const promise = Promise.resolve($.get('https://api.github.com/repos/bemusic/bemuse/releases'))
     promise.then(
       releases => this.setState({ data: { status: 'completed', releases } }),
       ()       => this.setState({ data: { status: 'error' } }),
     )
-  },
+  }
+
   render () {
     return (
       <Panel className="ChangelogPanel" title="What’s New">
@@ -25,7 +32,8 @@ export const ChangelogPanel = React.createClass({
         </div>
       </Panel>
     )
-  },
+  }
+
   getMarkdown () {
     const releasesPage = '[releases page on GitHub](https://github.com/bemusic/bemuse/releases)'
     if (this.state.data.status === 'loading') {
@@ -53,7 +61,7 @@ export const ChangelogPanel = React.createClass({
       'The change log for older versions are available at the ' + releasesPage
     )
     return changelog + '\n\n' + seeMore
-  },
-})
+  }
+}
 
 export default ChangelogPanel

--- a/src/app/ui/CustomBMS.jsx
+++ b/src/app/ui/CustomBMS.jsx
@@ -39,10 +39,10 @@ class CustomBMS extends React.Component {
         </div>
         <div className={c('CustomBMSのdropzone',
               { 'is-hover': this.state.hover })}
-          onDragOver={() => this.handleDragOver()}
-          onDragEnter={() => this.handleDragEnter()}
-          onDragLeave={() => this.handleDragLeave()}
-          onDrop={() => this.handleDrop()}>
+          onDragOver={this.handleDragOver}
+          onDragEnter={this.handleDragEnter}
+          onDragLeave={this.handleDragLeave}
+          onDrop={this.handleDrop}>
           {
             this.props.log
             ? (
@@ -67,21 +67,21 @@ class CustomBMS extends React.Component {
     </Panel>
   }
 
-  handleDragEnter (e) {
+  handleDragEnter = (e) => {
     e.preventDefault()
   }
 
-  handleDragOver (e) {
+  handleDragOver = (e) => {
     this.setState({ hover: true })
     e.preventDefault()
   }
 
-  handleDragLeave (e) {
+  handleDragLeave = (e) => {
     this.setState({ hover: false })
     e.preventDefault()
   }
 
-  handleDrop (e) {
+  handleDrop = (e) => {
     this.setState({ hover: false })
     Analytics.send('CustomBMS', 'drop')
     e.preventDefault()

--- a/src/app/ui/CustomBMS.jsx
+++ b/src/app/ui/CustomBMS.jsx
@@ -19,7 +19,12 @@ const enhance = compose(
   })
 )
 
-export const CustomBMS = React.createClass({
+class CustomBMS extends React.Component {
+  constructor () {
+    super()
+    this.state = this.getInitialState()
+  }
+
   render () {
     return <Panel className="CustomBMS" title="Load Custom BMS">
       <div className="CustomBMSのwrapper">
@@ -60,21 +65,26 @@ export const CustomBMS = React.createClass({
         </div>
       </div>
     </Panel>
-  },
+  }
+
   getInitialState () {
     return { hover: false }
-  },
+  }
+
   handleDragEnter (e) {
     e.preventDefault()
-  },
+  }
+
   handleDragOver (e) {
     this.setState({ hover: true })
     e.preventDefault()
-  },
+  }
+
   handleDragLeave (e) {
     this.setState({ hover: false })
     e.preventDefault()
-  },
+  }
+
   handleDrop (e) {
     this.setState({ hover: false })
     Analytics.send('CustomBMS', 'drop')
@@ -83,7 +93,7 @@ export const CustomBMS = React.createClass({
     promise.then((song) => {
       if (this.props.onSongLoaded) this.props.onSongLoaded(song)
     })
-  },
-})
+  }
+}
 
 export default enhance(CustomBMS)

--- a/src/app/ui/CustomBMS.jsx
+++ b/src/app/ui/CustomBMS.jsx
@@ -22,7 +22,7 @@ const enhance = compose(
 class CustomBMS extends React.Component {
   constructor () {
     super()
-    this.state = this.getInitialState()
+    this.state = { hover: false }
   }
 
   render () {
@@ -65,10 +65,6 @@ class CustomBMS extends React.Component {
         </div>
       </div>
     </Panel>
-  }
-
-  getInitialState () {
-    return { hover: false }
   }
 
   handleDragEnter (e) {

--- a/src/app/ui/CustomBMS.jsx
+++ b/src/app/ui/CustomBMS.jsx
@@ -39,10 +39,10 @@ class CustomBMS extends React.Component {
         </div>
         <div className={c('CustomBMSのdropzone',
               { 'is-hover': this.state.hover })}
-          onDragOver={this.handleDragOver}
-          onDragEnter={this.handleDragEnter}
-          onDragLeave={this.handleDragLeave}
-          onDrop={this.handleDrop}>
+          onDragOver={() => this.handleDragOver()}
+          onDragEnter={() => this.handleDragEnter()}
+          onDragLeave={() => this.handleDragLeave()}
+          onDrop={() => this.handleDrop()}>
           {
             this.props.log
             ? (

--- a/src/app/ui/ModeSelectScene.jsx
+++ b/src/app/ui/ModeSelectScene.jsx
@@ -19,10 +19,15 @@ const enhance = connectIO({
   )
 })
 
-export default enhance(React.createClass({
-  propTypes: {
+class ModeSelectScene extends React.Component {
+  static propTypes = {
     onSetMode: PropTypes.func,
-  },
+  }
+
+  constructor () {
+    super()
+  }
+
   render () {
     return <Scene className="ModeSelectScene">
       <SceneHeading>Select Mode</SceneHeading>
@@ -51,7 +56,8 @@ export default enhance(React.createClass({
         <a onClick={this.handleBack} href="javascript://">Go Back</a>
       </SceneToolbar>
     </Scene>
-  },
+  }
+
   renderKBGraphics () {
     let children = []
     for (let i = 0; i < 7; i++) {
@@ -65,7 +71,8 @@ export default enhance(React.createClass({
     }
     return <svg width="96" height="54" viewBox="0 0 96 54"
       className="ModeSelectSceneのgraphics">{children}</svg>
-  },
+  }
+
   renderBMGraphics () {
     let children = []
     for (let i = 0; i < 7; i++) {
@@ -79,19 +86,23 @@ export default enhance(React.createClass({
       <circle cx="21" cy="27" r="16" />
       {children}
     </svg>
-  },
+  }
 
   handleKB () {
     this.props.onSetMode('KB')
     SCENE_MANAGER.display(<MusicSelectScene />).done()
     Analytics.send('ModeSelectScene', 'select mode', 'KB')
-  },
+  }
+
   handleBM () {
     this.props.onSetMode('BM')
     SCENE_MANAGER.display(<MusicSelectScene />).done()
     Analytics.send('ModeSelectScene', 'select mode', 'BM')
-  },
+  }
+
   handleBack () {
     SCENE_MANAGER.pop().done()
-  },
-}))
+  }
+}
+
+export default enhance(ModeSelectScene)

--- a/src/app/ui/ModeSelectScene.jsx
+++ b/src/app/ui/ModeSelectScene.jsx
@@ -53,7 +53,7 @@ class ModeSelectScene extends React.Component {
         </div>
       </div>
       <SceneToolbar>
-        <a onClick={this.handleBack} href="javascript://">Go Back</a>
+        <a onClick={() => this.handleBack()} href="javascript://">Go Back</a>
       </SceneToolbar>
     </Scene>
   }

--- a/src/app/ui/ModeSelectScene.jsx
+++ b/src/app/ui/ModeSelectScene.jsx
@@ -33,7 +33,7 @@ class ModeSelectScene extends React.Component {
       <SceneHeading>Select Mode</SceneHeading>
       <div className="ModeSelectSceneのmain">
         <div className="ModeSelectSceneのcontent">
-          <div className="ModeSelectSceneのitem" onClick={this.handleKB}>
+          <div className="ModeSelectSceneのitem" onClick={() => this.handleKB()}>
             {this.renderKBGraphics()}
             <h2>Keyboard Mode</h2>
             <p>
@@ -41,7 +41,7 @@ class ModeSelectScene extends React.Component {
             </p>
             <p>This mode is similar to O2Jam.</p>
           </div>
-          <div className="ModeSelectSceneのitem" onClick={this.handleBM}>
+          <div className="ModeSelectSceneのitem" onClick={() => this.handleBM()}>
             {this.renderBMGraphics()}
             <h2>BMS Mode</h2>
             <p>

--- a/src/app/ui/ModeSelectScene.jsx
+++ b/src/app/ui/ModeSelectScene.jsx
@@ -24,10 +24,6 @@ class ModeSelectScene extends React.Component {
     onSetMode: PropTypes.func,
   }
 
-  constructor () {
-    super()
-  }
-
   render () {
     return <Scene className="ModeSelectScene">
       <SceneHeading>Select Mode</SceneHeading>

--- a/src/app/ui/ModeSelectScene.jsx
+++ b/src/app/ui/ModeSelectScene.jsx
@@ -33,7 +33,7 @@ class ModeSelectScene extends React.Component {
       <SceneHeading>Select Mode</SceneHeading>
       <div className="ModeSelectSceneのmain">
         <div className="ModeSelectSceneのcontent">
-          <div className="ModeSelectSceneのitem" onClick={() => this.handleKB()}>
+          <div className="ModeSelectSceneのitem" onClick={this.handleKB}>
             {this.renderKBGraphics()}
             <h2>Keyboard Mode</h2>
             <p>
@@ -41,7 +41,7 @@ class ModeSelectScene extends React.Component {
             </p>
             <p>This mode is similar to O2Jam.</p>
           </div>
-          <div className="ModeSelectSceneのitem" onClick={() => this.handleBM()}>
+          <div className="ModeSelectSceneのitem" onClick={this.handleBM}>
             {this.renderBMGraphics()}
             <h2>BMS Mode</h2>
             <p>
@@ -53,7 +53,7 @@ class ModeSelectScene extends React.Component {
         </div>
       </div>
       <SceneToolbar>
-        <a onClick={() => this.handleBack()} href="javascript://">Go Back</a>
+        <a onClick={this.handleBack} href="javascript://">Go Back</a>
       </SceneToolbar>
     </Scene>
   }
@@ -88,19 +88,19 @@ class ModeSelectScene extends React.Component {
     </svg>
   }
 
-  handleKB () {
+  handleKB = () => {
     this.props.onSetMode('KB')
     SCENE_MANAGER.display(<MusicSelectScene />).done()
     Analytics.send('ModeSelectScene', 'select mode', 'KB')
   }
 
-  handleBM () {
+  handleBM = () => {
     this.props.onSetMode('BM')
     SCENE_MANAGER.display(<MusicSelectScene />).done()
     Analytics.send('ModeSelectScene', 'select mode', 'BM')
   }
 
-  handleBack () {
+  handleBack = () => {
     SCENE_MANAGER.pop().done()
   }
 }

--- a/src/app/ui/MusicChartInfo.jsx
+++ b/src/app/ui/MusicChartInfo.jsx
@@ -3,8 +3,7 @@ import './MusicChartInfo.scss'
 
 import React from 'react'
 
-export default React.createClass({
-
+class MusicChartInfo extends React.Component {
   render () {
     const info = this.props.info
     return <section className="MusicChartInfo">
@@ -22,5 +21,6 @@ export default React.createClass({
       </div>
     </section>
   }
+}
 
-})
+export default MusicChartInfo

--- a/src/app/ui/MusicChartInfo.jsx
+++ b/src/app/ui/MusicChartInfo.jsx
@@ -3,24 +3,21 @@ import './MusicChartInfo.scss'
 
 import React from 'react'
 
-class MusicChartInfo extends React.Component {
-  render () {
-    const info = this.props.info
-    return <section className="MusicChartInfo">
-      <div className="MusicChartInfoのgenre">{info.genre}</div>
-      <div className="MusicChartInfoのtitle">{info.title}</div>
-      {info.subtitles.map((text, index) =>
-        <div className="MusicChartInfoのsubtitle" key={index}>{text}</div>)}
-      <div className="MusicChartInfoのartist">
-        {info.artist}
-        {
-          info.subartists.length
+const MusicChartInfo = ({ info }) => (
+  <section className="MusicChartInfo">
+    <div className="MusicChartInfoのgenre">{info.genre}</div>
+    <div className="MusicChartInfoのtitle">{info.title}</div>
+    {info.subtitles.map((text, index) =>
+      <div className="MusicChartInfoのsubtitle" key={index}>{text}</div>)}
+    <div className="MusicChartInfoのartist">
+      {info.artist}
+      {
+        info.subartists.length
           ? <small>{' · ' + info.subartists.join(' · ')}</small>
           : null
-        }
-      </div>
-    </section>
-  }
-}
+      }
+    </div>
+  </section>
+)
 
 export default MusicChartInfo

--- a/src/app/ui/MusicChartSelector.jsx
+++ b/src/app/ui/MusicChartSelector.jsx
@@ -4,8 +4,7 @@ import './MusicChartSelector.scss'
 import React from 'react'
 import MusicChartSelectorItem from './MusicChartSelectorItem.jsx'
 
-export default React.createClass({
-
+class MusicChartSelector extends React.Component {
   render () {
     return <ul className="MusicChartSelector">
       {this.props.charts.map((chart, index) =>
@@ -17,5 +16,6 @@ export default React.createClass({
           onChartClick={this.props.onChartClick} />)}
     </ul>
   }
+}
 
-})
+export default MusicChartSelector

--- a/src/app/ui/MusicChartSelectorItem.jsx
+++ b/src/app/ui/MusicChartSelectorItem.jsx
@@ -15,7 +15,7 @@ class MusicChartSelectorItem extends React.Component {
     })
     return <li
       className={classes}
-      onClick={this.handleClick}>
+      onClick={() => this.handleClick()}>
       {
         this.props.isTutorial
         ? (this.props.chart.keys === '5K'

--- a/src/app/ui/MusicChartSelectorItem.jsx
+++ b/src/app/ui/MusicChartSelectorItem.jsx
@@ -15,7 +15,7 @@ class MusicChartSelectorItem extends React.Component {
     })
     return <li
       className={classes}
-      onClick={() => this.handleClick()}>
+      onClick={this.handleClick}>
       {
         this.props.isTutorial
         ? (this.props.chart.keys === '5K'
@@ -34,7 +34,7 @@ class MusicChartSelectorItem extends React.Component {
     </li>
   }
 
-  handleClick () {
+  handleClick = () => {
     this.props.onChartClick(this.props.chart)
   }
 }

--- a/src/app/ui/MusicChartSelectorItem.jsx
+++ b/src/app/ui/MusicChartSelectorItem.jsx
@@ -4,8 +4,7 @@ import Icon   from 'react-fa'
 import React  from 'react'
 import c      from 'classnames'
 
-export default React.createClass({
-
+class MusicChartSelectorItem extends React.Component {
   render () {
     let classes = c('MusicChartSelectorItem', {
       'is-active': this.props.isSelected,
@@ -33,10 +32,11 @@ export default React.createClass({
         <Icon name="play" />
       </span>
     </li>
-  },
+  }
 
   handleClick () {
     this.props.onChartClick(this.props.chart)
-  },
+  }
+}
 
-})
+export default MusicChartSelectorItem

--- a/src/app/ui/MusicInfo.jsx
+++ b/src/app/ui/MusicInfo.jsx
@@ -5,7 +5,6 @@ import React from 'react'
 import MusicChartInfo     from './MusicChartInfo.jsx'
 import MusicChartSelector from './MusicChartSelector.jsx'
 import MusicInfoTabs      from './MusicInfoTabs.jsx'
-import pure               from 'recompose/pure'
 
 class MusicInfo extends React.PureComponent {
   render () {

--- a/src/app/ui/MusicInfo.jsx
+++ b/src/app/ui/MusicInfo.jsx
@@ -7,7 +7,7 @@ import MusicChartSelector from './MusicChartSelector.jsx'
 import MusicInfoTabs      from './MusicInfoTabs.jsx'
 import pure               from 'recompose/pure'
 
-export const MusicInfo = React.createClass({
+class MusicInfo extends React.PureComponent {
   render () {
     const song  = this.props.song
     const chart = this.props.chart
@@ -25,6 +25,6 @@ export const MusicInfo = React.createClass({
         onOptions={this.props.onOptions} />
     </section>
   }
-})
+}
 
-export default pure(MusicInfo)
+export default MusicInfo

--- a/src/app/ui/MusicInfoTabInformation.jsx
+++ b/src/app/ui/MusicInfoTabInformation.jsx
@@ -88,7 +88,7 @@ export default enhance(MusicInfoTabInformation)
 function link (text, url) {
   return (
     url
-    ? <a href={url} target="_blank">{text}</a>
+    ? <a key={text} href={url} target="_blank">{text}</a>
     : text
   )
 }

--- a/src/app/ui/MusicInfoTabInformation.jsx
+++ b/src/app/ui/MusicInfoTabInformation.jsx
@@ -22,20 +22,27 @@ const enhance = compose(
   })
 )
 
-export const MusicInfoTabInformation = React.createClass({
-  propTypes: {
+class MusicInfoTabInformation extends React.Component {
+  static propTypes = {
     song: PropTypes.object,
     readme: PropTypes.string,
     onRequestReadme: PropTypes.func
-  },
+  }
+
+  constructor () {
+    super()
+  }
+
   componentDidMount () {
     this.props.onRequestReadme(this.props.song)
-  },
+  }
+
   componentWillReceiveProps (nextProps) {
     if (nextProps.song !== this.props.song) {
       this.props.onRequestReadme(nextProps.song)
     }
-  },
+  }
+
   render () {
     const song = this.props.song
     return <div className="MusicInfoTabInformation">
@@ -49,7 +56,8 @@ export const MusicInfoTabInformation = React.createClass({
         <Markdown source={this.props.readme} />
       </section>
     </div>
-  },
+  }
+
   renderButtons () {
     let buttons = []
     let song = this.props.song
@@ -72,8 +80,8 @@ export const MusicInfoTabInformation = React.createClass({
     } else {
       return <p className="MusicInfoTabInformationのbuttons">{buttons}</p>
     }
-  },
-})
+  }
+}
 
 export default enhance(MusicInfoTabInformation)
 

--- a/src/app/ui/MusicInfoTabInformation.jsx
+++ b/src/app/ui/MusicInfoTabInformation.jsx
@@ -29,10 +29,6 @@ class MusicInfoTabInformation extends React.Component {
     onRequestReadme: PropTypes.func
   }
 
-  constructor () {
-    super()
-  }
-
   componentDidMount () {
     this.props.onRequestReadme(this.props.song)
   }

--- a/src/app/ui/MusicInfoTabStats.jsx
+++ b/src/app/ui/MusicInfoTabStats.jsx
@@ -8,13 +8,13 @@ import { formattedAccuracyForRecord } from 'bemuse/rules/accuracy'
 import formatTime from '../../utils/formatTime'
 import withPersonalRecord from './withPersonalRecord'
 
-export const MusicInfoTabStats = React.createClass({
-  propTypes: {
+class MusicInfoTabStats extends React.Component {
+  static propTypes = {
     chart: PropTypes.object,
     record: PropTypes.object,
     user: PropTypes.object,
     loading: PropTypes.bool
-  },
+  }
 
   render () {
     const chart = this.props.chart
@@ -50,14 +50,14 @@ export const MusicInfoTabStats = React.createClass({
         )}</dd>
       </dl>
     </div>
-  },
+  }
 
   renderWhenNotLoading (f) {
     return (this.props.loading
       ? <Icon name="spinner" spin />
       : f()
     )
-  },
+  }
 
   renderMessage () {
     if (!this.props.user) {
@@ -69,6 +69,6 @@ export const MusicInfoTabStats = React.createClass({
     }
     return null
   }
-})
+}
 
 export default withPersonalRecord(MusicInfoTabStats)

--- a/src/app/ui/MusicInfoTabs.jsx
+++ b/src/app/ui/MusicInfoTabs.jsx
@@ -9,7 +9,14 @@ import MusicInfoTabStats        from './MusicInfoTabStats.jsx'
 import MusicInfoTabInformation  from './MusicInfoTabInformation.jsx'
 import RankingContainer         from './RankingContainer'
 
-export default React.createClass({
+export default class MusicInfoTabs extends React.Component {
+
+  constructor () {
+    super()
+    this.state = {
+      selectedTab: 0,
+    }
+  }
 
   render () {
     return <section className="MusicInfoTabs">
@@ -27,7 +34,7 @@ export default React.createClass({
         {this.renderCurrentTab()}
       </div>
     </section>
-  },
+  }
 
   renderTab (index, title) {
     const onClick = () => this.setState({ selectedTab: index })
@@ -39,7 +46,8 @@ export default React.createClass({
     >
       {title}
     </li>
-  },
+  }
+
   renderCurrentTab () {
     switch (this.state.selectedTab) {
     case 0:
@@ -57,12 +65,6 @@ export default React.createClass({
     default:
       return 'Unknown tab'
     }
-  },
+  }
 
-  getInitialState () {
-    return {
-      selectedTab: 0,
-    }
-  },
-
-})
+}

--- a/src/app/ui/MusicInfoTabs.jsx
+++ b/src/app/ui/MusicInfoTabs.jsx
@@ -11,8 +11,8 @@ import RankingContainer         from './RankingContainer'
 
 export default class MusicInfoTabs extends React.Component {
 
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
     this.state = {
       selectedTab: 0,
     }

--- a/src/app/ui/MusicList.jsx
+++ b/src/app/ui/MusicList.jsx
@@ -4,7 +4,6 @@ import './MusicList.scss'
 import React          from 'react'
 import _              from 'lodash'
 import MusicListItem  from './MusicListItem.jsx'
-import pure           from 'recompose/pure'
 
 class MusicList extends React.PureComponent {
   render () {

--- a/src/app/ui/MusicList.jsx
+++ b/src/app/ui/MusicList.jsx
@@ -6,7 +6,7 @@ import _              from 'lodash'
 import MusicListItem  from './MusicListItem.jsx'
 import pure           from 'recompose/pure'
 
-export const MusicList = React.createClass({
+class MusicList extends React.PureComponent {
   render () {
     return <ul className="MusicList js-scrollable-view"
       onTouchStart={this.props.onTouch}>
@@ -22,7 +22,8 @@ export const MusicList = React.createClass({
           highlight={this.props.highlight} />),
       ])}
     </ul>
-  },
+  }
+
   getSelectedChart (song) {
     // Performance issue:
     //
@@ -36,6 +37,6 @@ export const MusicList = React.createClass({
     let selectedChart = this.props.selectedChart
     return _.find(song.charts, chart => chart === selectedChart)
   }
-})
+}
 
-export default pure(MusicList)
+export default MusicList

--- a/src/app/ui/MusicListItem.jsx
+++ b/src/app/ui/MusicListItem.jsx
@@ -16,7 +16,7 @@ class MusicListItem extends React.PureComponent {
     })
     return <li
       className={className}
-      onClick={this.handleClick}>
+      onClick={() => this.handleClick()}>
       {
         song.tutorial
         ? (
@@ -55,7 +55,7 @@ class MusicListItem extends React.PureComponent {
     return <MusicListItemCharts
       charts={getPlayableCharts(this.props.song.charts)}
       selectedChart={this.props.selectedChart}
-      onChartClick={this.handleChartClick}
+      onChartClick={() => this.handleChartClick()}
       playMode={this.props.playMode}
     />
   }

--- a/src/app/ui/MusicListItem.jsx
+++ b/src/app/ui/MusicListItem.jsx
@@ -16,7 +16,7 @@ class MusicListItem extends React.PureComponent {
     })
     return <li
       className={className}
-      onClick={() => this.handleClick()}>
+      onClick={this.handleClick}>
       {
         song.tutorial
         ? (
@@ -55,7 +55,7 @@ class MusicListItem extends React.PureComponent {
     return <MusicListItemCharts
       charts={getPlayableCharts(this.props.song.charts)}
       selectedChart={this.props.selectedChart}
-      onChartClick={() => this.handleChartClick()}
+      onChartClick={this.handleChartClick}
       playMode={this.props.playMode}
     />
   }
@@ -80,11 +80,11 @@ class MusicListItem extends React.PureComponent {
     return output
   }
 
-  handleClick () {
+  handleClick = () => {
     this.props.onSelect(this.props.song)
   }
 
-  handleChartClick (chart, e) {
+  handleChartClick = (chart, e) => {
     e.stopPropagation()
     this.props.onSelect(this.props.song, chart)
   }

--- a/src/app/ui/MusicListItem.jsx
+++ b/src/app/ui/MusicListItem.jsx
@@ -3,7 +3,6 @@ import './MusicListItem.scss'
 import React  from 'react'
 import c      from 'classnames'
 import getPlayableCharts from 'bemuse/music-collection/getPlayableCharts'
-import pure   from 'recompose/pure'
 
 import MusicListItemCharts from './MusicListItemCharts'
 

--- a/src/app/ui/MusicListItem.jsx
+++ b/src/app/ui/MusicListItem.jsx
@@ -7,7 +7,7 @@ import pure   from 'recompose/pure'
 
 import MusicListItemCharts from './MusicListItemCharts'
 
-export const MusicListItem = React.createClass({
+class MusicListItem extends React.PureComponent {
   render () {
     const song = this.props.song
     const className = c('MusicListItem', {
@@ -49,7 +49,8 @@ export const MusicListItem = React.createClass({
         )
       }
     </li>
-  },
+  }
+
   renderChartlist () {
     return <MusicListItemCharts
       charts={getPlayableCharts(this.props.song.charts)}
@@ -57,7 +58,8 @@ export const MusicListItem = React.createClass({
       onChartClick={this.handleChartClick}
       playMode={this.props.playMode}
     />
-  },
+  }
+
   renderHighlight (text) {
     if (!this.props.highlight) return text
     let highlight = this.props.highlight
@@ -76,16 +78,17 @@ export const MusicListItem = React.createClass({
       }
     }
     return output
-  },
+  }
 
   handleClick () {
     this.props.onSelect(this.props.song)
-  },
+  }
+
   handleChartClick (chart, e) {
     e.stopPropagation()
     this.props.onSelect(this.props.song, chart)
-  },
+  }
 
-})
+}
 
-export default pure(MusicListItem)
+export default MusicListItem

--- a/src/app/ui/MusicListItemChart.jsx
+++ b/src/app/ui/MusicListItemChart.jsx
@@ -11,7 +11,7 @@ export default class MusicListItemChart extends React.Component {
       'is-selected': !!this.props.selected,
       'is-grade': !!this.props.grade,
     })
-    return <div className={className} onClick={this.handleClick}>
+    return <div className={className} onClick={() => this.handleClick()}>
       <span className="MusicListItemChartのtext">
         {this.props.loading
           ? '…'

--- a/src/app/ui/MusicListItemChart.jsx
+++ b/src/app/ui/MusicListItemChart.jsx
@@ -11,7 +11,7 @@ export default class MusicListItemChart extends React.Component {
       'is-selected': !!this.props.selected,
       'is-grade': !!this.props.grade,
     })
-    return <div className={className} onClick={() => this.handleClick()}>
+    return <div className={className} onClick={this.handleClick}>
       <span className="MusicListItemChartのtext">
         {this.props.loading
           ? '…'
@@ -21,7 +21,7 @@ export default class MusicListItemChart extends React.Component {
     </div>
   }
 
-  handleClick (e) {
+  handleClick = (e) => {
     if (this.props.onClick) {
       this.props.onClick(this.props.chart, e)
     }

--- a/src/app/ui/MusicListItemChart.jsx
+++ b/src/app/ui/MusicListItemChart.jsx
@@ -3,7 +3,7 @@ import './MusicListItemChart.scss'
 import React from 'react'
 import c from 'classnames'
 
-export default React.createClass({
+export default class MusicListItemChart extends React.Component {
   render () {
     const chart = this.props.chart
     const className = c('MusicListItemChart', {
@@ -19,10 +19,11 @@ export default React.createClass({
         }
       </span>
     </div>
-  },
+  }
+
   handleClick (e) {
     if (this.props.onClick) {
       this.props.onClick(this.props.chart, e)
     }
-  },
-})
+  }
+}

--- a/src/app/ui/MusicListItemCharts.jsx
+++ b/src/app/ui/MusicListItemCharts.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import MusicListItemChartContainer from './MusicListItemChartContainer'
 
-export default React.createClass({
+export default class MusicListItemCharts extends React.Component {
   render () {
     return <div className="MusicListItemCharts">
       {this.props.charts.map((chart, index) =>
@@ -16,5 +16,5 @@ export default React.createClass({
           playMode={this.props.playMode} />
       )}
     </div>
-  },
-})
+  }
+}

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -85,8 +85,8 @@ const enhance = compose(
   pure
 )
 
-export const MusicSelectScene = React.createClass({
-  propTypes: {
+class MusicSelectScene extends React.Component {
+  static propTypes = {
     musicSelect: PropTypes.object,
     user: PropTypes.object,
     onSelectChart: PropTypes.func,
@@ -95,11 +95,24 @@ export const MusicSelectScene = React.createClass({
     onLaunchGame: PropTypes.func,
     collectionUrl: PropTypes.string,
     musicPreviewEnabled: PropTypes.bool,
-  },
+  }
+
+  constructor () {
+    super()
+    this.state = {
+      optionsVisible:               shouldShowOptions(),
+      customBMSVisible:             false,
+      unofficialDisclaimerVisible:  false,
+      inSong:                       false,
+      authenticationPopupVisible:   false,
+    }
+  }
+
   getPreviewUrl () {
     const song = this.props.musicSelect.song
     return getPreviewUrl(this.props.collectionUrl, song)
-  },
+  }
+
   render () {
     let musicSelect = this.props.musicSelect
     return <Scene
@@ -167,7 +180,8 @@ export const MusicSelectScene = React.createClass({
         <MusicSelectPreviewer url={this.getPreviewUrl()} />
       }
     </Scene>
-  },
+  }
+
   renderUnofficialDisclaimer () {
     if (!this.props.musicSelect.unofficial) return null
     return (
@@ -178,7 +192,8 @@ export const MusicSelectScene = React.createClass({
         <b>Disclaimer:</b> Unofficial Server
       </div>
     )
-  },
+  }
+
   renderMain () {
     const musicSelect = this.props.musicSelect
     if (musicSelect.loading) {
@@ -213,7 +228,8 @@ export const MusicSelectScene = React.createClass({
         />
       </div>
     )
-  },
+  }
+
   renderOnlineToolbarButtons () {
     if (!online) return null
     let buttons = []
@@ -232,20 +248,11 @@ export const MusicSelectScene = React.createClass({
       )
     }
     return buttons
-  },
+  }
 
-  getInitialState () {
-    return {
-      optionsVisible:               shouldShowOptions(),
-      customBMSVisible:             false,
-      unofficialDisclaimerVisible:  false,
-      inSong:                       false,
-      authenticationPopupVisible:   false,
-    }
-  },
   componentDidMount () {
     this.ensureSelectedSongInView()
-  },
+  }
   ensureSelectedSongInView () {
     const $this = $(ReactDOM.findDOMNode(this))
     const active = $this.find('.js-active-song')[0]
@@ -260,7 +267,7 @@ export const MusicSelectScene = React.createClass({
         (scrollerRect.top + scrollerRect.height / 2)
       )
     }
-  },
+  }
   handleSongSelect (song, chart) {
     if (chart) {
       this.props.onSelectChart(song, chart)
@@ -270,10 +277,10 @@ export const MusicSelectScene = React.createClass({
       Analytics.send('MusicSelectScene', 'select', 'song')
     }
     this.setState({ inSong: true })
-  },
+  }
   handleMusicListTouch () {
     this.setState({ inSong: false })
-  },
+  }
   handleChartClick (chart) {
     if (this.props.musicSelect.chart.md5 === chart.md5) {
       Analytics.send('MusicSelectScene', 'launch game')
@@ -283,53 +290,53 @@ export const MusicSelectScene = React.createClass({
       Analytics.send('MusicSelectScene', 'select chart')
       this.props.onSelectChart(this.props.musicSelect.song, chart)
     }
-  },
+  }
   handleFilter (e) {
     this.props.onFilterTextChange(e.target.value)
-  },
+  }
   handleOptionsOpen () {
     Analytics.send('MusicSelectScene', 'open options')
     this.setState({ optionsVisible: true })
-  },
+  }
   handleOptionsClose () {
     this.setState({ optionsVisible: false })
-  },
+  }
   handleCustomBMSOpen () {
     this.setState({ customBMSVisible: true })
     Analytics.send('MusicSelectScene', 'open custom BMS')
-  },
+  }
   handleCustomBMSClose () {
     this.setState({ customBMSVisible: false })
-  },
+  }
   handleCustomSong (song) {
     this.setState({ customBMSVisible: false })
-  },
+  }
   handleUnofficialClick () {
     this.setState({ unofficialDisclaimerVisible: true })
     Analytics.send('MusicSelectScene', 'view unofficial disclaimer')
-  },
+  }
   handleUnofficialClose () {
     this.setState({ unofficialDisclaimerVisible: false })
-  },
+  }
   handleLogout () {
     if (confirm('Do you really want to log out?')) {
       Promise.resolve(online.logOut()).done()
       Analytics.send('MusicSelectScene', 'logout')
     }
-  },
+  }
   handleAuthenticate () {
     this.setState({ authenticationPopupVisible: true })
     Analytics.send('MusicSelectScene', 'authenticate')
-  },
+  }
   handleAuthenticationClose () {
     this.setState({ authenticationPopupVisible: false })
-  },
+  }
   handleAuthenticationFinish () {
     this.setState({ authenticationPopupVisible: false })
-  },
+  }
   popScene () {
     SCENE_MANAGER.pop().done()
-  },
-})
+  }
+}
 
 export default enhance(MusicSelectScene)

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -322,7 +322,7 @@ class MusicSelectScene extends React.PureComponent {
       Analytics.send('MusicSelectScene', 'logout')
     }
   }
-  handleAuthenticatev = () => {
+  handleAuthenticate = () => {
     this.setState({ authenticationPopupVisible: true })
     Analytics.send('MusicSelectScene', 'authenticate')
   }

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -215,7 +215,7 @@ class MusicSelectScene extends React.Component {
           selectedSong={musicSelect.song}
           selectedChart={musicSelect.chart}
           playMode={musicSelect.playMode}
-          onSelect={() => this.handleSongSelect()}
+          onSelect={() => this.handleSongSelect(musicSelect.song)}
           onTouch={() => this.handleMusicListTouch()}
         />
         <MusicInfo
@@ -223,7 +223,7 @@ class MusicSelectScene extends React.Component {
           chart={musicSelect.chart}
           charts={musicSelect.charts}
           playMode={musicSelect.playMode}
-          onChartClick={() => this.handleChartClick()}
+          onChartClick={() => this.handleChartClick(musicSelect.chart)}
           onOptions={() => this.handleOptionsOpen()}
         />
       </div>

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -175,7 +175,7 @@ class MusicSelectScene extends React.PureComponent {
       />
 
       {!!this.props.musicPreviewEnabled &&
-        <MusicSelectPreviewer url={this.getPreviewUrl} />
+        <MusicSelectPreviewer url={this.getPreviewUrl()} />
       }
     </Scene>
   }

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -117,7 +117,7 @@ class MusicSelectScene extends React.Component {
     let musicSelect = this.props.musicSelect
     return <Scene
       className="MusicSelectScene"
-      onDragEnter={() => this.handleCustomBMSOpen()}
+      onDragEnter={this.handleCustomBMSOpen}
     >
       <SceneHeading>
         Select Music
@@ -125,7 +125,7 @@ class MusicSelectScene extends React.Component {
           type="text"
           placeholder="Filter…"
           className="MusicSelectSceneのsearch"
-          onChange={() => this.handleFilter()}
+          onChange={this.handleFilter}
           value={musicSelect.filterText}
         />
       </SceneHeading>
@@ -137,47 +137,47 @@ class MusicSelectScene extends React.Component {
       <SceneToolbar>
         <a onClick={this.popScene} href="javascript://">Exit</a>
         <a
-          onClick={() => this.handleCustomBMSOpen()}
+          onClick={this.handleCustomBMSOpen}
           href="javascript://"
         >
           Play Custom BMS
         </a>
         <SceneToolbar.Spacer />
         {this.renderOnlineToolbarButtons()}
-        <a onClick={() => this.handleOptionsOpen()} href="javascript://">Options</a>
+        <a onClick={this.handleOptionsOpen} href="javascript://">Options</a>
       </SceneToolbar>
 
       <ModalPopup
         visible={this.state.optionsVisible}
-        onBackdropClick={() => this.handleOptionsClose()}
+        onBackdropClick={this.handleOptionsClose}
       >
-        <OptionsView onClose={() => this.handleOptionsClose()} />
+        <OptionsView onClose={this.handleOptionsClose} />
       </ModalPopup>
 
       <ModalPopup
         visible={this.state.customBMSVisible}
-        onBackdropClick={() => this.handleCustomBMSClose()}
+        onBackdropClick={this.handleCustomBMSClose}
       >
         <div className="MusicSelectSceneのcustomBms">
-          <CustomBMS onSongLoaded={() => this.handleCustomSong()} />
+          <CustomBMS onSongLoaded={this.handleCustomSong} />
         </div>
       </ModalPopup>
 
       <ModalPopup
         visible={this.state.unofficialDisclaimerVisible}
-        onBackdropClick={() => this.handleUnofficialClose()}
+        onBackdropClick={this.handleUnofficialClose}
       >
-        <UnofficialPanel onClose={() => this.handleUnofficialClose()} />
+        <UnofficialPanel onClose={this.handleUnofficialClose} />
       </ModalPopup>
 
       <AuthenticationPopup
         visible={this.state.authenticationPopupVisible}
-        onFinish={() => this.handleAuthenticationFinish()}
-        onBackdropClick={() => this.handleAuthenticationClose()}
+        onFinish={this.handleAuthenticationFinish}
+        onBackdropClick={this.handleAuthenticationClose}
       />
 
       {!!this.props.musicPreviewEnabled &&
-        <MusicSelectPreviewer url={this.getPreviewUrl()} />
+        <MusicSelectPreviewer url={this.getPreviewUrl} />
       }
     </Scene>
   }
@@ -187,7 +187,7 @@ class MusicSelectScene extends React.Component {
     return (
       <div
         className="MusicSelectSceneのunofficialLabel"
-        onClick={() => this.handleUnofficialClick()}
+        onClick={this.handleUnofficialClick}
       >
         <b>Disclaimer:</b> Unofficial Server
       </div>
@@ -215,16 +215,16 @@ class MusicSelectScene extends React.Component {
           selectedSong={musicSelect.song}
           selectedChart={musicSelect.chart}
           playMode={musicSelect.playMode}
-          onSelect={() => this.handleSongSelect(musicSelect.song)}
-          onTouch={() => this.handleMusicListTouch()}
+          onSelect={this.handleSongSelect}
+          onTouch={this.handleMusicListTouch}
         />
         <MusicInfo
           song={musicSelect.song}
           chart={musicSelect.chart}
           charts={musicSelect.charts}
           playMode={musicSelect.playMode}
-          onChartClick={() => this.handleChartClick(musicSelect.chart)}
-          onOptions={() => this.handleOptionsOpen()}
+          onChartClick={this.handleChartClick}
+          onOptions={this.handleOptionsOpen}
         />
       </div>
     )
@@ -268,7 +268,7 @@ class MusicSelectScene extends React.Component {
       )
     }
   }
-  handleSongSelect (song, chart) {
+  handleSongSelect = (song, chart) => {
     if (chart) {
       this.props.onSelectChart(song, chart)
       Analytics.send('MusicSelectScene', 'select', 'song and chart')
@@ -278,10 +278,10 @@ class MusicSelectScene extends React.Component {
     }
     this.setState({ inSong: true })
   }
-  handleMusicListTouch () {
+  handleMusicListTouch = () => {
     this.setState({ inSong: false })
   }
-  handleChartClick (chart) {
+  handleChartClick = (chart) => {
     if (this.props.musicSelect.chart.md5 === chart.md5) {
       Analytics.send('MusicSelectScene', 'launch game')
       MusicPreviewer.go()
@@ -291,47 +291,47 @@ class MusicSelectScene extends React.Component {
       this.props.onSelectChart(this.props.musicSelect.song, chart)
     }
   }
-  handleFilter (e) {
+  handleFilter = (e) => {
     this.props.onFilterTextChange(e.target.value)
   }
-  handleOptionsOpen () {
+  handleOptionsOpen = () => {
     Analytics.send('MusicSelectScene', 'open options')
     this.setState({ optionsVisible: true })
   }
-  handleOptionsClose () {
+  handleOptionsClose = () => {
     this.setState({ optionsVisible: false })
   }
-  handleCustomBMSOpen () {
+  handleCustomBMSOpen = () => {
     this.setState({ customBMSVisible: true })
     Analytics.send('MusicSelectScene', 'open custom BMS')
   }
-  handleCustomBMSClose () {
+  handleCustomBMSClose = () => {
     this.setState({ customBMSVisible: false })
   }
-  handleCustomSong (song) {
+  handleCustomSong = (song) => {
     this.setState({ customBMSVisible: false })
   }
-  handleUnofficialClick () {
+  handleUnofficialClick = () => {
     this.setState({ unofficialDisclaimerVisible: true })
     Analytics.send('MusicSelectScene', 'view unofficial disclaimer')
   }
-  handleUnofficialClose () {
+  handleUnofficialClose = () => {
     this.setState({ unofficialDisclaimerVisible: false })
   }
-  handleLogout () {
+  handleLogout = () => {
     if (confirm('Do you really want to log out?')) {
       Promise.resolve(online.logOut()).done()
       Analytics.send('MusicSelectScene', 'logout')
     }
   }
-  handleAuthenticate () {
+  handleAuthenticatev = () => {
     this.setState({ authenticationPopupVisible: true })
     Analytics.send('MusicSelectScene', 'authenticate')
   }
-  handleAuthenticationClose () {
+  handleAuthenticationClose = () => {
     this.setState({ authenticationPopupVisible: false })
   }
-  handleAuthenticationFinish () {
+  handleAuthenticationFinish = () => {
     this.setState({ authenticationPopupVisible: false })
   }
   popScene () {

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -16,7 +16,6 @@ import c from 'classnames'
 import compose from 'recompose/compose'
 import getPreviewUrl from 'bemuse/music-collection/getPreviewUrl'
 import online from 'bemuse/online/instance'
-import pure from 'recompose/pure'
 import { OFFICIAL_SERVER_URL } from 'bemuse/music-collection'
 import { connect } from 'react-redux'
 import { connect as connectToLegacyStore } from 'bemuse/flux'
@@ -81,11 +80,10 @@ const enhance = compose(
     onLaunchGame: ({ musicSelect }) => () => (
       MusicSelectionIO.launchGame(musicSelect.server, musicSelect.song, musicSelect.chart)
     )
-  }),
-  pure
+  })
 )
 
-class MusicSelectScene extends React.Component {
+class MusicSelectScene extends React.PureComponent {
   static propTypes = {
     musicSelect: PropTypes.object,
     user: PropTypes.object,

--- a/src/app/ui/MusicSelectScene.jsx
+++ b/src/app/ui/MusicSelectScene.jsx
@@ -117,7 +117,7 @@ class MusicSelectScene extends React.Component {
     let musicSelect = this.props.musicSelect
     return <Scene
       className="MusicSelectScene"
-      onDragEnter={this.handleCustomBMSOpen}
+      onDragEnter={() => this.handleCustomBMSOpen()}
     >
       <SceneHeading>
         Select Music
@@ -125,7 +125,7 @@ class MusicSelectScene extends React.Component {
           type="text"
           placeholder="Filter…"
           className="MusicSelectSceneのsearch"
-          onChange={this.handleFilter}
+          onChange={() => this.handleFilter()}
           value={musicSelect.filterText}
         />
       </SceneHeading>
@@ -137,43 +137,43 @@ class MusicSelectScene extends React.Component {
       <SceneToolbar>
         <a onClick={this.popScene} href="javascript://">Exit</a>
         <a
-          onClick={this.handleCustomBMSOpen}
+          onClick={() => this.handleCustomBMSOpen()}
           href="javascript://"
         >
           Play Custom BMS
         </a>
         <SceneToolbar.Spacer />
         {this.renderOnlineToolbarButtons()}
-        <a onClick={this.handleOptionsOpen} href="javascript://">Options</a>
+        <a onClick={() => this.handleOptionsOpen()} href="javascript://">Options</a>
       </SceneToolbar>
 
       <ModalPopup
         visible={this.state.optionsVisible}
-        onBackdropClick={this.handleOptionsClose}
+        onBackdropClick={() => this.handleOptionsClose()}
       >
-        <OptionsView onClose={this.handleOptionsClose} />
+        <OptionsView onClose={() => this.handleOptionsClose()} />
       </ModalPopup>
 
       <ModalPopup
         visible={this.state.customBMSVisible}
-        onBackdropClick={this.handleCustomBMSClose}
+        onBackdropClick={() => this.handleCustomBMSClose()}
       >
         <div className="MusicSelectSceneのcustomBms">
-          <CustomBMS onSongLoaded={this.handleCustomSong} />
+          <CustomBMS onSongLoaded={() => this.handleCustomSong()} />
         </div>
       </ModalPopup>
 
       <ModalPopup
         visible={this.state.unofficialDisclaimerVisible}
-        onBackdropClick={this.handleUnofficialClose}
+        onBackdropClick={() => this.handleUnofficialClose()}
       >
-        <UnofficialPanel onClose={this.handleUnofficialClose} />
+        <UnofficialPanel onClose={() => this.handleUnofficialClose()} />
       </ModalPopup>
 
       <AuthenticationPopup
         visible={this.state.authenticationPopupVisible}
-        onFinish={this.handleAuthenticationFinish}
-        onBackdropClick={this.handleAuthenticationClose}
+        onFinish={() => this.handleAuthenticationFinish()}
+        onBackdropClick={() => this.handleAuthenticationClose()}
       />
 
       {!!this.props.musicPreviewEnabled &&
@@ -187,7 +187,7 @@ class MusicSelectScene extends React.Component {
     return (
       <div
         className="MusicSelectSceneのunofficialLabel"
-        onClick={this.handleUnofficialClick}
+        onClick={() => this.handleUnofficialClick()}
       >
         <b>Disclaimer:</b> Unofficial Server
       </div>
@@ -215,16 +215,16 @@ class MusicSelectScene extends React.Component {
           selectedSong={musicSelect.song}
           selectedChart={musicSelect.chart}
           playMode={musicSelect.playMode}
-          onSelect={this.handleSongSelect}
-          onTouch={this.handleMusicListTouch}
+          onSelect={() => this.handleSongSelect()}
+          onTouch={() => this.handleMusicListTouch()}
         />
         <MusicInfo
           song={musicSelect.song}
           chart={musicSelect.chart}
           charts={musicSelect.charts}
           playMode={musicSelect.playMode}
-          onChartClick={this.handleChartClick}
-          onOptions={this.handleOptionsOpen}
+          onChartClick={() => this.handleChartClick()}
+          onOptions={() => this.handleOptionsOpen()}
         />
       </div>
     )

--- a/src/app/ui/Options.jsx
+++ b/src/app/ui/Options.jsx
@@ -5,7 +5,7 @@ import OptionsPlayer    from './OptionsPlayer'
 import OptionsInput     from './OptionsInput'
 import OptionsAdvanced  from './OptionsAdvanced'
 
-export default React.createClass({
+export default class Options extends React.Component {
   render () {
     return <div className="Options">
       <Panel title="Player Settings">
@@ -22,4 +22,4 @@ export default React.createClass({
       </div>
     </div>
   }
-})
+}

--- a/src/app/ui/OptionsAdvanced.jsx
+++ b/src/app/ui/OptionsAdvanced.jsx
@@ -22,21 +22,21 @@ const enhance = compose(
   pure
 )
 
-export const OptionsAdvanced = React.createClass({
-  propTypes: {
+class OptionsAdvanced extends React.Component {
+  static propTypes = {
     options: PropTypes.object,
     onUpdateOptions: PropTypes.func
-  },
+  }
   stringifyLatency (latency) {
     return Math.round(latency) + 'ms'
-  },
+  }
   parseLatency (latencyText) {
     return parseInt(latencyText, 10)
-  },
+  }
   render () {
     let options = this.props.options
     return <div className="OptionsAdvanced">
-      <LatencyMessageListener onLatency={this.handleAudioInputLatencyChange} />
+      <LatencyMessageListener onLatency={() => this.handleAudioInputLatencyChange()} />
       <div className="OptionsAdvancedのgroup">
         <label>Latency</label>
         <div className="OptionsAdvancedのgroupItem">
@@ -45,41 +45,41 @@ export const OptionsAdvanced = React.createClass({
             parse={this.parseLatency}
             stringify={this.stringifyLatency}
             validator={/^\d+(?:ms)?$/}
-            onChange={this.handleAudioInputLatencyChange} />
+            onChange={() => this.handleAudioInputLatencyChange()} />
           <label>audio</label>
         </div>
         <OptionsButton
-          onClick={this.handleCalibrateButtonClick}>Calibrate</OptionsButton>
+          onClick={() => this.handleCalibrateButtonClick()}>Calibrate</OptionsButton>
       </div>
     </div>
-  },
+  }
   handleAudioInputLatencyChange (value) {
     this.props.onUpdateOptions(Options.changeAudioInputLatency(value))
-  },
+  }
   handleCalibrateButtonClick () {
     let options = 'width=640,height=360'
     window.open('?mode=sync', 'sync', options)
-  },
-})
+  }
+}
 
 export default enhance(OptionsAdvanced)
 
-const LatencyMessageListener = React.createClass({
-  propTypes: {
+class LatencyMessageListener extends React.Component {
+  static propTypes = {
     onLatency: PropTypes.func
-  },
+  }
   render () {
     return null
-  },
+  }
   componentDidMount () {
-    window.addEventListener('message', this.handleMessage)
-  },
+    window.addEventListener('message', () => this.handleMessage())
+  }
   componentWillUnmount () {
-    window.removeEventListener('message', this.handleMessage)
-  },
+    window.removeEventListener('message', () => this.handleMessage())
+  }
   handleMessage (event) {
     if (event.data && typeof event.data.latency === 'number') {
       this.props.onLatency(event.data.latency)
     }
-  },
-})
+  }
+}

--- a/src/app/ui/OptionsAdvanced.jsx
+++ b/src/app/ui/OptionsAdvanced.jsx
@@ -36,7 +36,7 @@ class OptionsAdvanced extends React.Component {
   render () {
     let options = this.props.options
     return <div className="OptionsAdvanced">
-      <LatencyMessageListener onLatency={() => this.handleAudioInputLatencyChange()} />
+      <LatencyMessageListener onLatency={this.handleAudioInputLatencyChange} />
       <div className="OptionsAdvancedのgroup">
         <label>Latency</label>
         <div className="OptionsAdvancedのgroupItem">
@@ -45,18 +45,18 @@ class OptionsAdvanced extends React.Component {
             parse={this.parseLatency}
             stringify={this.stringifyLatency}
             validator={/^\d+(?:ms)?$/}
-            onChange={() => this.handleAudioInputLatencyChange()} />
+            onChange={this.handleAudioInputLatencyChange} />
           <label>audio</label>
         </div>
         <OptionsButton
-          onClick={() => this.handleCalibrateButtonClick()}>Calibrate</OptionsButton>
+          onClick={this.handleCalibrateButtonClick}>Calibrate</OptionsButton>
       </div>
     </div>
   }
-  handleAudioInputLatencyChange (value) {
+  handleAudioInputLatencyChange = (value) => {
     this.props.onUpdateOptions(Options.changeAudioInputLatency(value))
   }
-  handleCalibrateButtonClick () {
+  handleCalibrateButtonClick = () => {
     let options = 'width=640,height=360'
     window.open('?mode=sync', 'sync', options)
   }
@@ -72,12 +72,12 @@ class LatencyMessageListener extends React.Component {
     return null
   }
   componentDidMount () {
-    window.addEventListener('message', () => this.handleMessage())
+    window.addEventListener('message', this.handleMessage)
   }
   componentWillUnmount () {
-    window.removeEventListener('message', () => this.handleMessage())
+    window.removeEventListener('message', this.handleMessage)
   }
-  handleMessage (event) {
+  handleMessage = (event) => {
     if (event.data && typeof event.data.latency === 'number') {
       this.props.onLatency(event.data.latency)
     }

--- a/src/app/ui/OptionsButton.jsx
+++ b/src/app/ui/OptionsButton.jsx
@@ -7,3 +7,5 @@ const OptionsButton = ({ children, onClick }) => (
     {children}
   </button>
 )
+
+export default OptionsButton

--- a/src/app/ui/OptionsButton.jsx
+++ b/src/app/ui/OptionsButton.jsx
@@ -2,10 +2,8 @@
 import './OptionsButton.scss'
 import React from 'react'
 
-export default React.createClass({
-  render () {
-    return <button className="OptionsButton" onClick={this.props.onClick}>
-      {this.props.children}
-    </button>
-  }
-})
+const OptionsButton = ({ children, onClick }) => (
+  <button className="OptionsButton" onClick={onClick}>
+    {children}
+  </button>
+)

--- a/src/app/ui/OptionsInput.jsx
+++ b/src/app/ui/OptionsInput.jsx
@@ -58,7 +58,7 @@ const enhance = compose(
 class OptionsInput extends React.Component {
   static propTypes = {
     scratch: PropTypes.string,
-    texts: PropTypes.array,
+    texts: PropTypes.object,
     editing: PropTypes.string,
     mode: PropTypes.string,
   }

--- a/src/app/ui/OptionsInput.jsx
+++ b/src/app/ui/OptionsInput.jsx
@@ -55,13 +55,13 @@ const enhance = compose(
   })
 )
 
-export const OptionsInput = React.createClass({
-  propTypes: {
+class OptionsInput extends React.Component {
+  static propTypes = {
     scratch: PropTypes.string,
     texts: PropTypes.array,
     editing: PropTypes.string,
     mode: PropTypes.string,
-  },
+  }
   render () {
     const className = c('OptionsInput', {
       'is-reverse': this.props.scratch === 'right'
@@ -106,30 +106,30 @@ export const OptionsInput = React.createClass({
         </div>
       </div>
     </div>
-  },
+  }
   handleEdit (key) {
     this.props.onEdit(key)
-  },
+  }
   componentDidMount () {
     // XXX: debounce is needed because some gamepad inputs trigger multiple
     // buttons
     this._dispose = key川().debounceImmediate(16).doLog('a').onValue(this.handleKey)
     window.addEventListener('keydown', this.handleKeyboardEvent, true)
-  },
+  }
   componentWillUnmount () {
     if (this._dispose) this._dispose()
     window.removeEventListener('keydown', this.handleKeyboardEvent, true)
-  },
+  }
   handleKey (key) {
     if (this.props.editing) {
       this.props.onKey(key)
     }
-  },
+  }
   handleKeyboardEvent (e) {
     if (this.props.editing) {
       e.preventDefault()
     }
   }
-})
+}
 
 export default enhance(OptionsInput)

--- a/src/app/ui/OptionsInput.jsx
+++ b/src/app/ui/OptionsInput.jsx
@@ -82,7 +82,7 @@ class OptionsInput extends React.Component {
                   ? 0
                   : this.props.editing === 'SC2' ? 1 : -1
                 }
-                onEdit={() => this.handleEdit()}
+                onEdit={this.handleEdit}
               />
             </div>
             <div className="OptionsInputのtitle">
@@ -98,7 +98,7 @@ class OptionsInput extends React.Component {
             keyboardMode={this.props.scratch === 'off'}
             texts={this.props.texts}
             editing={this.props.editing}
-            onEdit={() => this.handleEdit()}
+            onEdit={this.handleEdit}
           />
         </div>
         <div className="OptionsInputのtitle">
@@ -107,7 +107,7 @@ class OptionsInput extends React.Component {
       </div>
     </div>
   }
-  handleEdit (key) {
+  handleEdit = (key) => {
     this.props.onEdit(key)
   }
   componentDidMount () {
@@ -120,12 +120,12 @@ class OptionsInput extends React.Component {
     if (this._dispose) this._dispose()
     window.removeEventListener('keydown', this.handleKeyboardEvent, true)
   }
-  handleKey (key) {
+  handleKey = (key) => {
     if (this.props.editing) {
       this.props.onKey(key)
     }
   }
-  handleKeyboardEvent (e) {
+  handleKeyboardEvent = (e) => {
     if (this.props.editing) {
       e.preventDefault()
     }

--- a/src/app/ui/OptionsInput.jsx
+++ b/src/app/ui/OptionsInput.jsx
@@ -82,7 +82,7 @@ class OptionsInput extends React.Component {
                   ? 0
                   : this.props.editing === 'SC2' ? 1 : -1
                 }
-                onEdit={this.handleEdit}
+                onEdit={() => this.handleEdit()}
               />
             </div>
             <div className="OptionsInputのtitle">
@@ -98,7 +98,7 @@ class OptionsInput extends React.Component {
             keyboardMode={this.props.scratch === 'off'}
             texts={this.props.texts}
             editing={this.props.editing}
-            onEdit={this.handleEdit}
+            onEdit={() => this.handleEdit()}
           />
         </div>
         <div className="OptionsInputのtitle">

--- a/src/app/ui/OptionsInputField.jsx
+++ b/src/app/ui/OptionsInputField.jsx
@@ -30,12 +30,12 @@ class OptionsInputField extends React.PureComponent {
       type="text"
       ref="input"
       defaultValue={this.props.stringify(this.props.value)}
-      onChange={() => this.handleInputChange()}
-      onKeyDown={() => this.handleInputKeyDown()}
-      onBlur={() => this.handleInputBlur()}
+      onChange={this.handleInputChange}
+      onKeyDown={this.handleInputKeyDown}
+      onBlur={this.handleInputBlur}
       className="OptionsInputField" />
   }
-  handleInputChange (e) {
+  handleInputChange = (e) => {
     let input = e.target
     let valid = this.props.validator.test(input.value)
     input.classList[valid ? 'remove' : 'add']('is-invalid')
@@ -43,7 +43,7 @@ class OptionsInputField extends React.PureComponent {
       this.props.onChange(this.props.parse(input.value))
     }
   }
-  handleInputBlur () {
+  handleInputBlur = () => {
     let input = ReactDOM.findDOMNode(this.refs.input)
     input.value = this.props.stringify(this.props.value)
     input.classList.remove('is-invalid')

--- a/src/app/ui/OptionsInputField.jsx
+++ b/src/app/ui/OptionsInputField.jsx
@@ -19,10 +19,6 @@ class OptionsInputField extends React.PureComponent {
     onChange: () => {},
   }
 
-  constructor () {
-    super()
-  }
-
   render () {
     return <input
       {..._.omit(this.props, ['stringify', 'parse', 'onChange', 'validator', 'value'])}

--- a/src/app/ui/OptionsInputField.jsx
+++ b/src/app/ui/OptionsInputField.jsx
@@ -30,9 +30,9 @@ class OptionsInputField extends React.PureComponent {
       type="text"
       ref="input"
       defaultValue={this.props.stringify(this.props.value)}
-      onChange={this.handleInputChange}
-      onKeyDown={this.handleInputKeyDown}
-      onBlur={this.handleInputBlur}
+      onChange={() => this.handleInputChange()}
+      onKeyDown={() => this.handleInputKeyDown()}
+      onBlur={() => this.handleInputBlur()}
       className="OptionsInputField" />
   }
   handleInputChange (e) {

--- a/src/app/ui/OptionsInputField.jsx
+++ b/src/app/ui/OptionsInputField.jsx
@@ -4,7 +4,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
-import pure from 'recompose/pure'
 
 class OptionsInputField extends React.PureComponent {
   static propTypes = {

--- a/src/app/ui/OptionsInputField.jsx
+++ b/src/app/ui/OptionsInputField.jsx
@@ -6,21 +6,24 @@ import PropTypes from 'prop-types'
 import _ from 'lodash'
 import pure from 'recompose/pure'
 
-export const OptionsInputField = React.createClass({
-  propTypes: {
+class OptionsInputField extends React.PureComponent {
+  static propTypes = {
     stringify: PropTypes.func,
     parse: PropTypes.func,
     onChange: PropTypes.func,
     validator: PropTypes.object,
     value: PropTypes.any,
-  },
-  getDefaultProps () {
-    return {
-      stringify: x => `${x}`,
-      parse:     x => x,
-      onChange: () => {},
-    }
-  },
+  }
+  static defaultProps = {
+    stringify: x => `${x}`,
+    parse:     x => x,
+    onChange: () => {},
+  }
+
+  constructor () {
+    super()
+  }
+
   render () {
     return <input
       {..._.omit(this.props, ['stringify', 'parse', 'onChange', 'validator', 'value'])}
@@ -31,7 +34,7 @@ export const OptionsInputField = React.createClass({
       onKeyDown={this.handleInputKeyDown}
       onBlur={this.handleInputBlur}
       className="OptionsInputField" />
-  },
+  }
   handleInputChange (e) {
     let input = e.target
     let valid = this.props.validator.test(input.value)
@@ -39,12 +42,12 @@ export const OptionsInputField = React.createClass({
     if (valid) {
       this.props.onChange(this.props.parse(input.value))
     }
-  },
+  }
   handleInputBlur () {
     let input = ReactDOM.findDOMNode(this.refs.input)
     input.value = this.props.stringify(this.props.value)
     input.classList.remove('is-invalid')
-  },
+  }
   componentDidUpdate (previousProps, previousState) {
     let newValue = this.props.stringify(this.props.value)
     if (this.props.stringify(previousProps.value) !== newValue) {
@@ -55,7 +58,7 @@ export const OptionsInputField = React.createClass({
         }
       }
     }
-  },
-})
+  }
+}
 
-export default pure(OptionsInputField)
+export default OptionsInputField

--- a/src/app/ui/OptionsInputKey.jsx
+++ b/src/app/ui/OptionsInputKey.jsx
@@ -4,20 +4,20 @@ import React from 'react'
 import c     from 'classnames'
 import pure  from 'recompose/pure'
 
-export const OptionsInputKey = React.createClass({
+class OptionsInputKey extends React.PureComponent {
   render () {
     return <div className="OptionsInputKey" data-n={this.props.n}>
       <div
         className={c('OptionsInputKeyのcontents',
               { 'is-editing': this.props.isEditing })}
-        onClick={this.handleClick}>
+        onClick={() => this.handleClick()}>
         <div className="OptionsInputKeyのtext">{this.props.text}</div>
       </div>
     </div>
-  },
+  }
   handleClick () {
     this.props.onEdit('' + this.props.n)
-  },
-})
+  }
+}
 
-export default pure(OptionsInputKey)
+export default OptionsInputKey

--- a/src/app/ui/OptionsInputKey.jsx
+++ b/src/app/ui/OptionsInputKey.jsx
@@ -2,7 +2,6 @@
 import './OptionsInputKey.scss'
 import React from 'react'
 import c     from 'classnames'
-import pure  from 'recompose/pure'
 
 class OptionsInputKey extends React.PureComponent {
   render () {

--- a/src/app/ui/OptionsInputKey.jsx
+++ b/src/app/ui/OptionsInputKey.jsx
@@ -10,12 +10,12 @@ class OptionsInputKey extends React.PureComponent {
       <div
         className={c('OptionsInputKeyのcontents',
               { 'is-editing': this.props.isEditing })}
-        onClick={() => this.handleClick()}>
+        onClick={this.handleClick}>
         <div className="OptionsInputKeyのtext">{this.props.text}</div>
       </div>
     </div>
   }
-  handleClick () {
+  handleClick = () => {
     this.props.onEdit('' + this.props.n)
   }
 }

--- a/src/app/ui/OptionsInputKeys.jsx
+++ b/src/app/ui/OptionsInputKeys.jsx
@@ -1,7 +1,6 @@
 
 import './OptionsInputKeys.scss'
 import React from 'react'
-import pure  from 'recompose/pure'
 
 import OptionsInputKey from './OptionsInputKey'
 

--- a/src/app/ui/OptionsInputKeys.jsx
+++ b/src/app/ui/OptionsInputKeys.jsx
@@ -5,7 +5,7 @@ import pure  from 'recompose/pure'
 
 import OptionsInputKey from './OptionsInputKey'
 
-export const OptionsInputKeys = React.createClass({
+class OptionsInputKeys extends React.PureComponent {
   render () {
     let keys = []
     for (let i = 1; i <= 7; i++) {
@@ -23,6 +23,6 @@ export const OptionsInputKeys = React.createClass({
       </div>
     </div>
   }
-})
+}
 
-export default pure(OptionsInputKeys)
+export default OptionsInputKeys

--- a/src/app/ui/OptionsInputScratch.jsx
+++ b/src/app/ui/OptionsInputScratch.jsx
@@ -9,7 +9,7 @@ class OptionsInputScratch extends React.PureComponent {
     return <div
       className={c('OptionsInputScratch',
             { 'is-editing': this.props.isEditing })}
-      onClick={this.handleClick}>
+      onClick={() => this.handleClick()}>
       <svg viewBox="-100 -100 200 200">
         <path d={star()} className="OptionsInputScratchのstar" />
       </svg>

--- a/src/app/ui/OptionsInputScratch.jsx
+++ b/src/app/ui/OptionsInputScratch.jsx
@@ -1,7 +1,6 @@
 
 import './OptionsInputScratch.scss'
 import React from 'react'
-import pure  from 'recompose/pure'
 import c     from 'classnames'
 
 class OptionsInputScratch extends React.PureComponent {

--- a/src/app/ui/OptionsInputScratch.jsx
+++ b/src/app/ui/OptionsInputScratch.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import pure  from 'recompose/pure'
 import c     from 'classnames'
 
-export const OptionsInputScratch = React.createClass({
+class OptionsInputScratch extends React.PureComponent {
   render () {
     return <div
       className={c('OptionsInputScratch',
@@ -19,18 +19,18 @@ export const OptionsInputScratch = React.createClass({
         <div className={this.renderKeyClass(1)}>{this.props.text[1]}</div>
       </div>
     </div>
-  },
+  }
   renderKeyClass (index) {
     return c('OptionsInputScratchのkey', {
       'is-editing': this.props.editIndex === index
     })
-  },
+  }
   handleClick () {
     this.props.onEdit('SC')
-  },
-})
+  }
+}
 
-export default pure(OptionsInputScratch)
+export default OptionsInputScratch
 
 function star () {
   let out = ''

--- a/src/app/ui/OptionsInputScratch.jsx
+++ b/src/app/ui/OptionsInputScratch.jsx
@@ -9,7 +9,7 @@ class OptionsInputScratch extends React.PureComponent {
     return <div
       className={c('OptionsInputScratch',
             { 'is-editing': this.props.isEditing })}
-      onClick={() => this.handleClick()}>
+      onClick={this.handleClick}>
       <svg viewBox="-100 -100 200 200">
         <path d={star()} className="OptionsInputScratchのstar" />
       </svg>
@@ -25,7 +25,7 @@ class OptionsInputScratch extends React.PureComponent {
       'is-editing': this.props.editIndex === index
     })
   }
-  handleClick () {
+  handleClick = () => {
     this.props.onEdit('SC')
   }
 }

--- a/src/app/ui/OptionsPlayer.jsx
+++ b/src/app/ui/OptionsPlayer.jsx
@@ -30,10 +30,10 @@ const SettingRow = compose(
   )
 })
 
-export const OptionsPlayer = React.createClass({
-  propTypes: {
+class OptionsPlayer extends React.Component {
+  static propTypes = {
     onClose: PropTypes.func
-  },
+  }
   render () {
     return <div className="OptionsPlayer">
       <SettingRow
@@ -165,14 +165,14 @@ export const OptionsPlayer = React.createClass({
       </div>
     </div>
   }
-})
+}
 
-OptionsPlayer.Row = React.createClass({
-  propTypes: {
+class OptionsPlayerRow extends React.Component {
+  static propTypes = {
     hidden: PropTypes.bool,
     label: PropTypes.node,
     children: PropTypes.node
-  },
+  }
   render () {
     return <div
       className="OptionsPlayerのrow"
@@ -182,6 +182,8 @@ OptionsPlayer.Row = React.createClass({
       <div>{this.props.children}</div>
     </div>
   }
-})
+}
+
+OptionsPlayer.Row = OptionsPlayerRow
 
 export default OptionsPlayer

--- a/src/app/ui/OptionsPlayerGraphics.jsx
+++ b/src/app/ui/OptionsPlayerGraphics.jsx
@@ -20,7 +20,7 @@ const PANEL_PATH = (function () {
           L${x4} ${y4} L${x4} ${y3} L${x3} ${y2} L${x3} ${y1}`
 })()
 
-export default React.createClass({
+export default class OptionsPlayerGraphics extends React.Component {
   render () {
     let svg =
       this.props.type === 'scratch'
@@ -30,7 +30,7 @@ export default React.createClass({
         { 'is-active': this.props.active })}>
       {svg}
     </div>
-  },
+  }
   renderScratch () {
     let p = this.props.value
     let bx = p === 'left' ? 24 : p === 'right' ? 4 : 14
@@ -59,7 +59,7 @@ export default React.createClass({
       <line className="OptionsPlayerGraphicsのline"
         x1="1" x2="95" y1="29" y2="29" />
     </svg>
-  },
+  }
   renderPanel () {
     let p = this.props.value
     let tx = p === 'left' ? -35 : p === 'right' ? 35 : 0
@@ -71,4 +71,4 @@ export default React.createClass({
       </g>
     </svg>
   }
-})
+}

--- a/src/app/ui/OptionsPlayerSelector.jsx
+++ b/src/app/ui/OptionsPlayerSelector.jsx
@@ -28,7 +28,7 @@ class OptionsPlayerSelectorItem extends React.PureComponent {
     return <div
       className={c('OptionsPlayerSelectorのitem',
             { 'is-active': this.props.active })}
-      onClick={this.handleClick}>
+      onClick={() => this.handleClick()}>
       <OptionsPlayerGraphics
         type={this.props.type}
         value={this.props.value}

--- a/src/app/ui/OptionsPlayerSelector.jsx
+++ b/src/app/ui/OptionsPlayerSelector.jsx
@@ -2,11 +2,10 @@
 import './OptionsPlayerSelector.scss'
 import React from 'react'
 import c     from 'classnames'
-import pure  from 'recompose/pure'
 
 import OptionsPlayerGraphics from './OptionsPlayerGraphics'
 
-class OptionsPlayerSelector extends React.Component {
+class OptionsPlayerSelector extends React.PureComponent {
   render () {
     return <div className="OptionsPlayerSelector">
       {this.props.options.map((item, index) =>
@@ -45,4 +44,4 @@ class OptionsPlayerSelectorItem extends React.PureComponent {
 
 OptionsPlayerSelector.Item = OptionsPlayerSelectorItem
 
-export default pure(OptionsPlayerSelector)
+export default OptionsPlayerSelector

--- a/src/app/ui/OptionsPlayerSelector.jsx
+++ b/src/app/ui/OptionsPlayerSelector.jsx
@@ -6,7 +6,7 @@ import pure  from 'recompose/pure'
 
 import OptionsPlayerGraphics from './OptionsPlayerGraphics'
 
-const OptionsPlayerSelector = React.createClass({
+class OptionsPlayerSelector extends React.Component {
   render () {
     return <div className="OptionsPlayerSelector">
       {this.props.options.map((item, index) =>
@@ -21,9 +21,9 @@ const OptionsPlayerSelector = React.createClass({
       )}
     </div>
   }
-})
+}
 
-OptionsPlayerSelector.Item = pure(React.createClass({
+class OptionsPlayerSelectorItem extends React.PureComponent {
   render () {
     return <div
       className={c('OptionsPlayerSelectorのitem',
@@ -37,10 +37,12 @@ OptionsPlayerSelector.Item = pure(React.createClass({
         {this.props.label}
       </div>
     </div>
-  },
+  }
   handleClick () {
     this.props.onSelect(this.props.value)
-  },
-}))
+  }
+}
+
+OptionsPlayerSelector.Item = OptionsPlayerSelectorItem
 
 export default pure(OptionsPlayerSelector)

--- a/src/app/ui/OptionsPlayerSelector.jsx
+++ b/src/app/ui/OptionsPlayerSelector.jsx
@@ -28,7 +28,7 @@ class OptionsPlayerSelectorItem extends React.PureComponent {
     return <div
       className={c('OptionsPlayerSelectorのitem',
             { 'is-active': this.props.active })}
-      onClick={() => this.handleClick()}>
+      onClick={this.handleClick}>
       <OptionsPlayerGraphics
         type={this.props.type}
         value={this.props.value}
@@ -38,7 +38,7 @@ class OptionsPlayerSelectorItem extends React.PureComponent {
       </div>
     </div>
   }
-  handleClick () {
+  handleClick = () => {
     this.props.onSelect(this.props.value)
   }
 }

--- a/src/app/ui/OptionsSpeed.jsx
+++ b/src/app/ui/OptionsSpeed.jsx
@@ -28,16 +28,16 @@ class OptionsSpeed extends React.PureComponent {
   render () {
     return <div className="OptionsSpeed">
       <span className="OptionsSpeedのminus">
-        <OptionsButton onClick={this.handleMinusButtonClick}>-</OptionsButton>
+        <OptionsButton onClick={() => this.handleMinusButtonClick()}>-</OptionsButton>
       </span>
       <OptionsInputField
         value={this.parseSpeed(this.props.value)}
         parse={this.parseSpeed}
         stringify={this.stringifySpeed}
         validator={/^\d+(?:\.\d)?$/}
-        onChange={this.handleSpeedInputChange} />
+        onChange={() => this.handleSpeedInputChange()} />
       <span className="OptionsSpeedのplus">
-        <OptionsButton onClick={this.handlePlusButtonClick}>+</OptionsButton>
+        <OptionsButton onClick={() => this.handlePlusButtonClick()}>+</OptionsButton>
       </span>
     </div>
   }

--- a/src/app/ui/OptionsSpeed.jsx
+++ b/src/app/ui/OptionsSpeed.jsx
@@ -3,7 +3,6 @@ import './OptionsSpeed.scss'
 import OptionsButton from './OptionsButton'
 import OptionsInputField from './OptionsInputField'
 import React from 'react'
-import pure from 'recompose/pure'
 
 class OptionsSpeed extends React.PureComponent {
   parseSpeed (speedString) {

--- a/src/app/ui/OptionsSpeed.jsx
+++ b/src/app/ui/OptionsSpeed.jsx
@@ -12,32 +12,32 @@ class OptionsSpeed extends React.PureComponent {
   stringifySpeed (speed) {
     return speed.toFixed(1)
   }
-  handleMinusButtonClick () {
+  handleMinusButtonClick = () => {
     let speed = this.parseSpeed(this.props.value)
     let nextSpeed = speed - (speed > 0.5 ? 0.5 : speed > 0.2 ? 0.3 : 0)
     this.props.onChange(this.stringifySpeed(nextSpeed))
   }
-  handlePlusButtonClick () {
+  handlePlusButtonClick = () => {
     let speed = this.parseSpeed(this.props.value)
     let nextSpeed = speed + (speed < 0.5 ? 0.3 : 0.5)
     this.props.onChange(this.stringifySpeed(nextSpeed))
   }
-  handleSpeedInputChange (nextSpeed) {
+  handleSpeedInputChange = (nextSpeed) => {
     this.props.onChange(this.stringifySpeed(nextSpeed))
   }
   render () {
     return <div className="OptionsSpeed">
       <span className="OptionsSpeedのminus">
-        <OptionsButton onClick={() => this.handleMinusButtonClick()}>-</OptionsButton>
+        <OptionsButton onClick={this.handleMinusButtonClick}>-</OptionsButton>
       </span>
       <OptionsInputField
         value={this.parseSpeed(this.props.value)}
         parse={this.parseSpeed}
         stringify={this.stringifySpeed}
         validator={/^\d+(?:\.\d)?$/}
-        onChange={() => this.handleSpeedInputChange()} />
+        onChange={this.handleSpeedInputChange} />
       <span className="OptionsSpeedのplus">
-        <OptionsButton onClick={() => this.handlePlusButtonClick()}>+</OptionsButton>
+        <OptionsButton onClick={this.handlePlusButtonClick}>+</OptionsButton>
       </span>
     </div>
   }

--- a/src/app/ui/OptionsSpeed.jsx
+++ b/src/app/ui/OptionsSpeed.jsx
@@ -5,26 +5,26 @@ import OptionsInputField from './OptionsInputField'
 import React from 'react'
 import pure from 'recompose/pure'
 
-export const OptionsSpeed = React.createClass({
+class OptionsSpeed extends React.PureComponent {
   parseSpeed (speedString) {
     return +(+speedString || 1.0).toFixed(1)
-  },
+  }
   stringifySpeed (speed) {
     return speed.toFixed(1)
-  },
+  }
   handleMinusButtonClick () {
     let speed = this.parseSpeed(this.props.value)
     let nextSpeed = speed - (speed > 0.5 ? 0.5 : speed > 0.2 ? 0.3 : 0)
     this.props.onChange(this.stringifySpeed(nextSpeed))
-  },
+  }
   handlePlusButtonClick () {
     let speed = this.parseSpeed(this.props.value)
     let nextSpeed = speed + (speed < 0.5 ? 0.3 : 0.5)
     this.props.onChange(this.stringifySpeed(nextSpeed))
-  },
+  }
   handleSpeedInputChange (nextSpeed) {
     this.props.onChange(this.stringifySpeed(nextSpeed))
-  },
+  }
   render () {
     return <div className="OptionsSpeed">
       <span className="OptionsSpeedのminus">
@@ -40,7 +40,7 @@ export const OptionsSpeed = React.createClass({
         <OptionsButton onClick={this.handlePlusButtonClick}>+</OptionsButton>
       </span>
     </div>
-  },
-})
+  }
+}
 
-export default pure(OptionsSpeed)
+export default OptionsSpeed

--- a/src/app/ui/Ranking.jsx
+++ b/src/app/ui/Ranking.jsx
@@ -5,31 +5,32 @@ import RankingTable from './RankingTable'
 import AuthenticationPopup from 'bemuse/online/ui/AuthenticationPopup'
 import { isWaiting } from 'bemuse/online/operations'
 
-export default React.createClass({
-  getInitialState () {
-    return {
+export default class Ranking extends React.Component {
+  constructor () {
+    super()
+    this.state = {
       authenticationPopupVisible: false,
     }
-  },
+  }
   handleAuthenticate () {
     this.setState({ authenticationPopupVisible: true })
-  },
+  }
   handleAuthenticationClose () {
     this.setState({ authenticationPopupVisible: false })
-  },
+  }
   handleAuthenticationFinish () {
     this.setState({ authenticationPopupVisible: false })
-  },
+  }
   render () {
     return <div className="Ranking">
       <AuthenticationPopup
         visible={this.state.authenticationPopupVisible}
-        onFinish={this.handleAuthenticationFinish}
-        onBackdropClick={this.handleAuthenticationClose} />
+        onFinish={() => this.handleAuthenticationFinish()}
+        onBackdropClick={() => this.handleAuthenticationClose()} />
       {this.renderYours()}
       {this.renderLeaderboard()}
     </div>
-  },
+  }
   renderYours () {
     const state = this.props.state
     const submission = state.meta.submission
@@ -78,7 +79,7 @@ export default React.createClass({
         }
       </RankingTable>
     </div>
-  },
+  }
   renderLeaderboard () {
     const state = this.props.state
     return <div className="Rankingのleaderboard">
@@ -118,7 +119,7 @@ export default React.createClass({
         }
       </RankingTable>
     </div>
-  },
+  }
   renderError (text, error, retry) {
     return <span className="Rankingのerror">
       <strong>
@@ -138,4 +139,4 @@ export default React.createClass({
       </span>
     </span>
   }
-})
+}

--- a/src/app/ui/Ranking.jsx
+++ b/src/app/ui/Ranking.jsx
@@ -12,21 +12,21 @@ export default class Ranking extends React.Component {
       authenticationPopupVisible: false,
     }
   }
-  handleAuthenticate () {
+  handleAuthenticate = () => {
     this.setState({ authenticationPopupVisible: true })
   }
-  handleAuthenticationClose () {
+  handleAuthenticationClose = () => {
     this.setState({ authenticationPopupVisible: false })
   }
-  handleAuthenticationFinish () {
+  handleAuthenticationFinish = () => {
     this.setState({ authenticationPopupVisible: false })
   }
   render () {
     return <div className="Ranking">
       <AuthenticationPopup
         visible={this.state.authenticationPopupVisible}
-        onFinish={() => this.handleAuthenticationFinish()}
-        onBackdropClick={() => this.handleAuthenticationClose()} />
+        onFinish={this.handleAuthenticationFinish}
+        onBackdropClick={this.handleAuthenticationClose} />
       {this.renderYours()}
       {this.renderLeaderboard()}
     </div>

--- a/src/app/ui/RankingContainer.jsx
+++ b/src/app/ui/RankingContainer.jsx
@@ -38,6 +38,7 @@ export default class RankingContainer extends React.Component {
   componentDidMount () {
     this.model        = online.Ranking(this.getParams(this.props))
     this.unsubscribe  = this.model.state川.onValue(this.onStoreTrigger)
+    this.mounted      = true
   }
 
   componentWillReceiveProps (nextProps) {
@@ -49,11 +50,12 @@ export default class RankingContainer extends React.Component {
   }
 
   componentWillUnmount () {
+    this.mounted = false
     if (this.unsubscribe) this.unsubscribe()
   }
 
-  onStoreTrigger (state) {
-    if (this.isMounted()) this.setState(state)
+  onStoreTrigger = (state) => {
+    if (this.mounted) this.setState(state)
   }
 
   onReloadScoreboardRequest () {

--- a/src/app/ui/RankingContainer.jsx
+++ b/src/app/ui/RankingContainer.jsx
@@ -3,17 +3,18 @@ import React    from 'react'
 import Ranking  from './Ranking'
 import online   from 'bemuse/online/instance'
 
-export default React.createClass({
+export default class RankingContainer extends React.Component {
 
-  getInitialState () {
-    return {
+  constructor () {
+    super()
+    this.state = {
       data: null,
       meta: {
         scoreboard: { status: 'loading' },
         submission: { status: 'loading' },
       }
     }
-  },
+  }
 
   getParams (props) {
     let params = { }
@@ -32,12 +33,12 @@ export default React.createClass({
       })
     }
     return params
-  },
+  }
 
   componentDidMount () {
     this.model        = online.Ranking(this.getParams(this.props))
     this.unsubscribe  = this.model.state川.onValue(this.onStoreTrigger)
-  },
+  }
 
   componentWillReceiveProps (nextProps) {
     if (this.props.chart.md5 !== nextProps.chart.md5 || this.props.playMode !== nextProps.playMode) {
@@ -45,23 +46,23 @@ export default React.createClass({
       this.model        = online.Ranking(this.getParams(nextProps))
       this.unsubscribe  = this.model.state川.onValue(this.onStoreTrigger)
     }
-  },
+  }
 
   componentWillUnmount () {
     if (this.unsubscribe) this.unsubscribe()
-  },
+  }
 
   onStoreTrigger (state) {
     if (this.isMounted()) this.setState(state)
-  },
+  }
 
   onReloadScoreboardRequest () {
     this.model.reloadScoreboard()
-  },
+  }
 
   onResubmitScoreRequest () {
     this.model.resubmit()
-  },
+  }
 
   render () {
     return (
@@ -71,5 +72,5 @@ export default React.createClass({
         onResubmitScoreRequest={this.onResubmitScoreRequest}
       />
     )
-  },
-})
+  }
+}

--- a/src/app/ui/RankingTable.jsx
+++ b/src/app/ui/RankingTable.jsx
@@ -3,17 +3,15 @@ import './RankingTable.scss'
 import React from 'react'
 import { formattedAccuracyForRecord } from 'bemuse/rules/accuracy'
 
-export const RankingTable = React.createClass({
-  render () {
-    return <table className="RankingTable">
-      <tbody>
-        {this.props.children}
-      </tbody>
-    </table>
-  }
-})
+const RankingTable = ({ children }) => (
+  <table className="RankingTable">
+    <tbody>
+      {children}
+    </tbody>
+  </table>
+)
 
-export const Row = React.createClass({
+class Row extends React.Component {
   render () {
     return <tr>
       <td className="RankingTableのrank">
@@ -29,18 +27,16 @@ export const Row = React.createClass({
         {formattedAccuracyForRecord(this.props.record)}
       </td>
     </tr>
-  },
-})
+  }
+}
 
-export const Message = React.createClass({
-  render () {
-    return <tr>
-      <td colSpan={4} className="RankingTableのmessage">
-        {this.props.children}
-      </td>
-    </tr>
-  },
-})
+export const Message = ({ children }) => (
+  <tr>
+    <td colSpan={4} className="RankingTableのmessage">
+      {children}
+    </td>
+  </tr>
+)
 
 RankingTable.Row = Row
 RankingTable.Message = Message

--- a/src/app/ui/ResultDeltasView.jsx
+++ b/src/app/ui/ResultDeltasView.jsx
@@ -19,10 +19,11 @@ const group = deltas => (_(deltas)
   .value()
 )
 
-export default React.createClass({
-  propTypes: {
+export default class ResultDeltasView extends React.Component {
+  static propTypes = {
     deltas: PropTypes.array
-  },
+  }
+
   render () {
     const deltas = this.props.deltas
     const nonMissDeltas = getNonMissedDeltas(deltas)
@@ -67,7 +68,8 @@ export default React.createClass({
         </Panel>
       </div>
     )
-  },
+  }
+
   renderRow (text, data, options = { }) {
     return (
       <tr>
@@ -79,5 +81,5 @@ export default React.createClass({
         }</td>
       </tr>
     )
-  },
-})
+  }
+}

--- a/src/app/ui/ResultDeltasView.jsx
+++ b/src/app/ui/ResultDeltasView.jsx
@@ -44,6 +44,7 @@ export default class ResultDeltasView extends React.Component {
             <div className="ResultDeltasViewのhistogram">
               {stats.map(({ bucket, count }) =>
                 <div
+                  key={bucket}
                   className="ResultDeltasViewのhistogramBar"
                   data-bucket={bucket}
                   style={{ height: height(count) }}

--- a/src/app/ui/ResultGrade.jsx
+++ b/src/app/ui/ResultGrade.jsx
@@ -2,11 +2,11 @@
 import './ResultGrade.scss'
 import React from 'react'
 
-export default React.createClass({
-  render () {
-    return <div className="ResultGrade">
-      <div className="ResultGradeのlabel">GRADE</div>
-      <div className="ResultGradeのgrade">{this.props.grade}</div>
-    </div>
-  }
-})
+const ResultGrade = ({ grade }) => (
+  <div className="ResultGrade">
+    <div className="ResultGradeのlabel">GRADE</div>
+    <div className="ResultGradeのgrade">{grade}</div>
+  </div>
+)
+
+export default ResultGrade

--- a/src/app/ui/ResultScene.jsx
+++ b/src/app/ui/ResultScene.jsx
@@ -68,7 +68,7 @@ export default class ResultScene extends React.Component {
           </a>
           <Flex grow={1} />
           <FirstTimeTip tip="Back to music selection" featureKey="finishGame">
-            <div className="ResultSceneのexit" onClick={this.handleExit}>
+            <div className="ResultSceneのexit" onClick={() => this.handleExit()}>
               Continue
             </div>
           </FirstTimeTip>

--- a/src/app/ui/ResultScene.jsx
+++ b/src/app/ui/ResultScene.jsx
@@ -68,7 +68,7 @@ export default class ResultScene extends React.Component {
           </a>
           <Flex grow={1} />
           <FirstTimeTip tip="Back to music selection" featureKey="finishGame">
-            <div className="ResultSceneのexit" onClick={() => this.handleExit()}>
+            <div className="ResultSceneのexit" onClick={this.handleExit}>
               Continue
             </div>
           </FirstTimeTip>

--- a/src/app/ui/ResultTable.jsx
+++ b/src/app/ui/ResultTable.jsx
@@ -9,13 +9,14 @@ import RunningNumber    from 'bemuse/ui/RunningNumber'
 import FirstTimeTip     from './FirstTimeTip'
 import ResultDeltasView from './ResultDeltasView'
 
-export default React.createClass({
-  propTypes: {
+export default class ResultTable extends React.Component {
+  static propType = {
     result: PropTypes.object
-  },
-  getInitialState () {
-    return { deltasModalVisible: false }
-  },
+  }
+  constructor () {
+    super()
+    this.state = { deltasModalVisible: false }
+  }
   render () {
     let result = this.props.result
     return <div className="ResultTable">
@@ -77,15 +78,15 @@ export default React.createClass({
         <ResultDeltasView deltas={result['deltas']} />
       </ModalPopup>
     </div>
-  },
+  }
   formatAccuracy (value) {
     return (value * 100).toFixed(2) + '%'
-  },
+  }
   handleToggleDeltasModal () {
     this.setState({ deltasModalVisible: !this.state.deltasModalVisible })
-  },
+  }
   handleViewDeltas () {
     this.handleToggleDeltasModal()
     Analytics.send('ResultTable', 'view deltas')
-  },
-})
+  }
+}

--- a/src/app/ui/ResultTable.jsx
+++ b/src/app/ui/ResultTable.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
             <th>Max Combo</th>
           </tr>
           <tr>
-            <td onClick={this.handleViewDeltas} className="is-clickable">
+            <td onClick={() => this.handleViewDeltas()} className="is-clickable">
               <FirstTimeTip featureKey="deltas" tip="View detailed accuracy data">
                 <RunningNumber
                   formatter={this.formatAccuracy}
@@ -72,7 +72,7 @@ export default React.createClass({
       </table>
       <ModalPopup
         visible={this.state.deltasModalVisible}
-        onBackdropClick={this.handleToggleDeltasModal}
+        onBackdropClick={() => this.handleToggleDeltasModal()}
       >
         <ResultDeltasView deltas={result['deltas']} />
       </ModalPopup>

--- a/src/app/ui/ResultTable.jsx
+++ b/src/app/ui/ResultTable.jsx
@@ -51,7 +51,7 @@ export default class ResultTable extends React.Component {
             <th>Max Combo</th>
           </tr>
           <tr>
-            <td onClick={() => this.handleViewDeltas()} className="is-clickable">
+            <td onClick={this.handleViewDeltas} className="is-clickable">
               <FirstTimeTip featureKey="deltas" tip="View detailed accuracy data">
                 <RunningNumber
                   formatter={this.formatAccuracy}
@@ -73,7 +73,7 @@ export default class ResultTable extends React.Component {
       </table>
       <ModalPopup
         visible={this.state.deltasModalVisible}
-        onBackdropClick={() => this.handleToggleDeltasModal()}
+        onBackdropClick={this.handleToggleDeltasModal}
       >
         <ResultDeltasView deltas={result['deltas']} />
       </ModalPopup>
@@ -82,10 +82,10 @@ export default class ResultTable extends React.Component {
   formatAccuracy (value) {
     return (value * 100).toFixed(2) + '%'
   }
-  handleToggleDeltasModal () {
+  handleToggleDeltasModal = () => {
     this.setState({ deltasModalVisible: !this.state.deltasModalVisible })
   }
-  handleViewDeltas () {
+  handleViewDeltas = () => {
     this.handleToggleDeltasModal()
     Analytics.send('ResultTable', 'view deltas')
   }

--- a/src/app/ui/TitleScene.jsx
+++ b/src/app/ui/TitleScene.jsx
@@ -43,17 +43,20 @@ const enhance = compose(
   })
 ))
 
-export const TitleScene = React.createClass({
-  propTypes: {
+class TitleScene extends React.Component {
+  static propTypes = {
     hasSeenChangelog: PropTypes.bool,
     clickedTwitterButton: PropTypes.bool,
     onMarkChangelogAsSeen: PropTypes.func.isRequired,
-  },
-  getInitialState () {
-    return {
+  }
+
+  constructor () {
+    super()
+    this.state = {
       changelogModalVisible: false,
     }
-  },
+  }
+
   render () {
     const shouldShowHomepage = !HAS_PARENT
     return <Scene className="TitleScene">
@@ -75,7 +78,7 @@ export const TitleScene = React.createClass({
       <SceneToolbar>
         <a onClick={this.showAbout} href="javascript://">About</a>
         <a onClick={this.openLink} href="https://bemuse.readthedocs.org">Docs</a>
-        <a onClick={this.viewChangelog} href="javascript://">{this.renderVersion()}</a>
+        <a onClick={() => this.viewChangelog()} href="javascript://">{this.renderVersion()}</a>
         <SceneToolbar.Spacer />
         <a onClick={this.openLink} href="https://www.facebook.com/bemusegame">Facebook</a>
         <a onClick={this.openTwitterLink} href="https://twitter.com/bemusegame">
@@ -88,12 +91,12 @@ export const TitleScene = React.createClass({
       <div className="TitleSceneのcurtain"></div>
       <ModalPopup
         visible={this.state.changelogModalVisible}
-        onBackdropClick={this.toggleChangelogModal}
+        onBackdropClick={() => this.toggleChangelogModal()}
       >
         <ChangelogPanel />
       </ModalPopup>
     </Scene>
-  },
+  }
 
   renderVersion () {
     return (
@@ -101,16 +104,18 @@ export const TitleScene = React.createClass({
         <strong>Bemuse</strong> v{version}
       </TipContainer>
     )
-  },
+  }
 
   openLink (e) {
     e.preventDefault()
     window.open($(e.target).closest('a').get(0).href, '_blank')
-  },
+  }
+
   openTwitterLink (e) {
     this.openLink(e)
     this.props.onTwitterButtonClick()
-  },
+  }
+
   enterGame () {
     SCENE_MANAGER.push(<ModeSelectScene />).done()
     Analytics.send('TitleScene', 'enter game')
@@ -120,20 +125,23 @@ export const TitleScene = React.createClass({
                   !/Chrom/.test(navigator.userAgent)
       if (!safari) screenfull.request()
     }
-  },
+  }
+
   showAbout () {
     SCENE_MANAGER.push(<AboutScene />).done()
     Analytics.send('TitleScene', 'show about')
-  },
+  }
+
   viewChangelog () {
     this.toggleChangelogModal()
     this.props.onMarkChangelogAsSeen()
     Analytics.send('TitleScene', 'view changelog')
-  },
+  }
+
   toggleChangelogModal () {
     this.setState({ changelogModalVisible: !this.state.changelogModalVisible })
-  },
+  }
 
-})
+}
 
 export default enhance(TitleScene)

--- a/src/app/ui/TitleScene.jsx
+++ b/src/app/ui/TitleScene.jsx
@@ -80,8 +80,8 @@ class TitleScene extends React.Component {
         <a onClick={this.openLink} href="https://bemuse.readthedocs.org">Docs</a>
         <a onClick={() => this.viewChangelog()} href="javascript://">{this.renderVersion()}</a>
         <SceneToolbar.Spacer />
-        <a onClick={this.openLink} href="https://www.facebook.com/bemusegame">Facebook</a>
-        <a onClick={this.openTwitterLink} href="https://twitter.com/bemusegame">
+        <a onClick={() => this.openLink()} href="https://www.facebook.com/bemusegame">Facebook</a>
+        <a onClick={() => this.openTwitterLink()} href="https://twitter.com/bemusegame">
           <FirstTimeTip tip="Like & follow us :)" featureKey="twitter">
             Twitter
           </FirstTimeTip>

--- a/src/app/ui/UnofficialPanel.jsx
+++ b/src/app/ui/UnofficialPanel.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Panel from 'bemuse/ui/Panel'
 import OptionsButton from './OptionsButton'
 
-export default React.createClass({
+class UnofficialPanel extends React.Component {
   render () {
     return <div className="UnofficialPanel">
       <Panel title="Unofficial Music Server">
@@ -21,4 +21,6 @@ export default React.createClass({
       </Panel>
     </div>
   }
-})
+}
+
+export default UnofficialPanel

--- a/src/app/ui/withPersonalRecord.jsx
+++ b/src/app/ui/withPersonalRecord.jsx
@@ -24,13 +24,13 @@ export function withPersonalRecord (Component) {
     }))
   )
 
-  const WrappedClass = React.createClass({
+  class WrappedClass extends React.Component {
     componentDidMount () {
       online.seen(this.getLevel())
-    },
+    }
     componentDidUpdate () {
       online.seen(this.getLevel())
-    },
+    }
     render () {
       const recordState = this.getRecordState()
       return (
@@ -40,14 +40,14 @@ export function withPersonalRecord (Component) {
           {..._.omit(this.props, 'onlineRecords')}
         />
       )
-    },
+    }
     getRecordState (data) {
       return DataStore.get(this.props.onlineRecords, id(this.getLevel()))
-    },
+    }
     getLevel () {
       return { md5: this.props.chart.md5, playMode: this.props.playMode }
-    },
-  })
+    }
+  }
 
   return enhance(WrappedClass)
 }

--- a/src/auto-synchro/ui/ExperimentScene.jsx
+++ b/src/auto-synchro/ui/ExperimentScene.jsx
@@ -4,8 +4,8 @@ import React from 'react'
 import c from 'classnames'
 import Loading from 'bemuse/ui/Loading'
 
-export default React.createClass({
-  render () {
+export default class ExperimentScene extends React.Component {
+  render() {
     return <div className={c('ExperimentScene', { 'is-finished': this.props.finished })}>
       <div className="ExperimentSceneのwrapper">
         <div className="ExperimentSceneのwrapperInner">
@@ -13,8 +13,9 @@ export default React.createClass({
         </div>
       </div>
     </div>
-  },
-  renderContents () {
+  }
+
+  renderContents = () => {
     if (this.props.loading) {
       return this.renderLoading()
     } else if (!this.props.started) {
@@ -24,24 +25,28 @@ export default React.createClass({
     } else {
       return this.renderCollection()
     }
-  },
-  renderLoading () {
+  }
+
+  renderLoading = () => {
     return <div className="ExperimentSceneのloading">
       <Loading />
     </div>
-  },
-  renderReady () {
+  }
+
+  renderReady = () => {
     return <div className="ExperimentSceneのready">
       <button className="ExperimentSceneのbutton"
         onClick={this.props.onStart}>Start Calibration</button>
     </div>
-  },
-  renderMessage (text) {
+  }
+
+  renderMessage = (text) => {
     return <div className="ExperimentSceneのmessage">
       {text}
     </div>
-  },
-  renderCollection () {
+  }
+
+  renderCollection = () => {
     let scale = (
       this.props.finished
       ? 1
@@ -62,8 +67,8 @@ export default React.createClass({
         <div className="ExperimentSceneのprogressBar" style={style}></div>
       </div>
     </div>
-  },
-})
+  }
+}
 
 function easeOut (x) {
   return 1 - Math.pow(1 - x, 2)

--- a/src/auto-synchro/ui/ExperimentScene.jsx
+++ b/src/auto-synchro/ui/ExperimentScene.jsx
@@ -5,7 +5,7 @@ import c from 'classnames'
 import Loading from 'bemuse/ui/Loading'
 
 export default class ExperimentScene extends React.Component {
-  render() {
+  render () {
     return <div className={c('ExperimentScene', { 'is-finished': this.props.finished })}>
       <div className="ExperimentSceneのwrapper">
         <div className="ExperimentSceneのwrapperInner">

--- a/src/devtools/playground.js
+++ b/src/devtools/playground.js
@@ -13,13 +13,12 @@ const availablePlaygrounds = (function (context) {
   return playgrounds
 })(require.context('./playgrounds', false, /\.jsx?$/))
 
-const DefaultPlayground = React.createClass({
-  statics: {
-    main () {
-      ReactDOM.render(<DefaultPlayground />, MAIN)
-    }
-  },
-  render () {
+class DefaultPlayground extends React.Component {
+  static main() {
+    ReactDOM.render(<DefaultPlayground />, MAIN)
+  }
+
+  render() {
     const linkStyle = { color: '#abc' }
     return <div>
       <h1>Bemuse Playground</h1>
@@ -33,7 +32,7 @@ const DefaultPlayground = React.createClass({
       </ul>
     </div>
   }
-})
+}
 
 export function main () {
   void (availablePlaygrounds[query.playground] || DefaultPlayground).main()

--- a/src/devtools/playground.js
+++ b/src/devtools/playground.js
@@ -14,11 +14,11 @@ const availablePlaygrounds = (function (context) {
 })(require.context('./playgrounds', false, /\.jsx?$/))
 
 class DefaultPlayground extends React.Component {
-  static main() {
+  static main () {
     ReactDOM.render(<DefaultPlayground />, MAIN)
   }
 
-  render() {
+  render () {
     const linkStyle = { color: '#abc' }
     return <div>
       <h1>Bemuse Playground</h1>

--- a/src/devtools/playgrounds/drop-bms.jsx
+++ b/src/devtools/playgrounds/drop-bms.jsx
@@ -4,13 +4,11 @@ import MAIN  from 'bemuse/utils/main-element'
 import CustomBMS from 'bemuse/app/ui/CustomBMS'
 import ReactDOM from 'react-dom'
 
-const DropBMSScene = React.createClass({
-  render () {
-    return <div>
-      <CustomBMS />
-    </div>
-  }
-})
+const DropBMSScene = () => (
+  <div>
+    <CustomBMS />
+  </div>
+)
 
 export function main () {
   ReactDOM.render(<DropBMSScene />, MAIN)

--- a/src/devtools/playgrounds/online-authentication.jsx
+++ b/src/devtools/playgrounds/online-authentication.jsx
@@ -1,16 +1,14 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import MAIN  from 'bemuse/utils/main-element'
+import MAIN from 'bemuse/utils/main-element'
 import AuthenticationPopup from 'bemuse/online/ui/AuthenticationPopup'
 
-const OnlineAuthenticationTestScene = React.createClass({
-  render () {
-    return <div>
-      <AuthenticationPopup />
-    </div>
-  }
-})
+const OnlineAuthenticationTestScene = () => (
+  <div>
+    <AuthenticationPopup />
+  </div>
+)
 
 export function main () {
   ReactDOM.render(<OnlineAuthenticationTestScene />, MAIN)

--- a/src/devtools/playgrounds/options.jsx
+++ b/src/devtools/playgrounds/options.jsx
@@ -7,13 +7,11 @@ import Options    from 'bemuse/app/ui/Options'
 
 const noop = () => { }
 
-const OptionsPlayground = React.createClass({
-  render () {
-    return <ModalPopup visible onBackdropClick={noop}>
-      <Options onClose={noop} />
-    </ModalPopup>
-  }
-})
+const OptionsPlayground = () => (
+  <ModalPopup visible onBackdropClick={noop}>
+    <Options onClose={noop} />
+  </ModalPopup>
+)
 
 export function main () {
   ReactDOM.render(<OptionsPlayground />, MAIN)

--- a/src/devtools/playgrounds/ranking-table.jsx
+++ b/src/devtools/playgrounds/ranking-table.jsx
@@ -1,90 +1,88 @@
 
-import React    from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
-import MAIN     from 'bemuse/utils/main-element'
-import Ranking  from 'bemuse/app/ui/Ranking'
+import MAIN from 'bemuse/utils/main-element'
+import Ranking from 'bemuse/app/ui/Ranking'
 import './ranking-table-playground.scss'
 
-const RankingTablePlayground = React.createClass({
-  render () {
-    return <div className="ranking-table-playground">
-      <Ranking
-        state={{
-          data: [
-            { playerName: 'One', score: '543210', count: [5, 4, 3, 2, 1], total: 15, rank: 1 },
-            { playerName: 'Two', score: '123456', count: [1, 2, 3, 4, 5], total: 15, rank: 2 },
-          ],
-          meta: {
-            scoreboard: {
-              status: 'completed',
-            },
-            submission: {
-              status: 'completed',
-              record: { playerName: 'One', score: '543210', count: [5, 4, 3, 2, 1], total: 15, rank: 1 },
-            }
+const RankingTablePlayground = () => (
+  <div className="ranking-table-playground">
+    <Ranking
+      state={{
+        data: [
+          { playerName: 'One', score: '543210', count: [5, 4, 3, 2, 1], total: 15, rank: 1 },
+          { playerName: 'Two', score: '123456', count: [1, 2, 3, 4, 5], total: 15, rank: 2 },
+        ],
+        meta: {
+          scoreboard: {
+            status: 'completed',
+          },
+          submission: {
+            status: 'completed',
+            record: { playerName: 'One', score: '543210', count: [5, 4, 3, 2, 1], total: 15, rank: 1 },
           }
-        }}
-      />
-      <Ranking
-        state={{
-          data: [
-            { playerName: 'One', score: '543210', count: [5, 4, 3, 2, 1], total: 15, rank: 1 },
-            { playerName: 'Two', score: '123456', count: [1, 2, 3, 4, 5], total: 15, rank: 2 },
-          ],
-          meta: {
-            scoreboard: {
-              status: 'completed',
-            },
-            submission: {
-              status: 'completed',
-              record: null,
-            }
+        }
+      }}
+    />
+    <Ranking
+      state={{
+        data: [
+          { playerName: 'One', score: '543210', count: [5, 4, 3, 2, 1], total: 15, rank: 1 },
+          { playerName: 'Two', score: '123456', count: [1, 2, 3, 4, 5], total: 15, rank: 2 },
+        ],
+        meta: {
+          scoreboard: {
+            status: 'completed',
+          },
+          submission: {
+            status: 'completed',
+            record: null,
           }
-        }}
-      />
-      <Ranking
-        state={{
-          data: null,
-          meta: {
-            scoreboard: {
-              status: 'completed',
-            },
-            submission: {
-              status: 'unauthenticated',
-            }
+        }
+      }}
+    />
+    <Ranking
+      state={{
+        data: null,
+        meta: {
+          scoreboard: {
+            status: 'completed',
+          },
+          submission: {
+            status: 'unauthenticated',
           }
-        }}
-      />
-      <Ranking
-        state={{
-          data: null,
-          meta: {
-            scoreboard: {
-              status: 'loading',
-            },
-            submission: {
-              status: 'loading',
-            }
+        }
+      }}
+    />
+    <Ranking
+      state={{
+        data: null,
+        meta: {
+          scoreboard: {
+            status: 'loading',
+          },
+          submission: {
+            status: 'loading',
           }
-        }}
-      />
-      <Ranking
-        state={{
-          data: null,
-          meta: {
-            scoreboard: {
-              status: 'error',
-            },
-            submission: {
-              status: 'error',
-            }
+        }
+      }}
+    />
+    <Ranking
+      state={{
+        data: null,
+        meta: {
+          scoreboard: {
+            status: 'error',
+          },
+          submission: {
+            status: 'error',
           }
-        }}
-      />
-    </div>
-  }
-})
+        }
+      }}
+    />
+  </div>
+)
 
-export function main () {
+export function main() {
   ReactDOM.render(<RankingTablePlayground />, MAIN)
 }

--- a/src/devtools/playgrounds/ranking-table.jsx
+++ b/src/devtools/playgrounds/ranking-table.jsx
@@ -83,6 +83,6 @@ const RankingTablePlayground = () => (
   </div>
 )
 
-export function main() {
+export function main () {
   ReactDOM.render(<RankingTablePlayground />, MAIN)
 }

--- a/src/devtools/ui/BenchmarkPanel.jsx
+++ b/src/devtools/ui/BenchmarkPanel.jsx
@@ -2,7 +2,7 @@
 import './BenchmarkPanel.scss'
 import React from 'react'
 
-export default class extends React.Component {
+export default class BenchmarkPanel extends React.Component {
   constructor (props) {
     super(props)
     this.state = {

--- a/src/devtools/ui/BenchmarkPanel.jsx
+++ b/src/devtools/ui/BenchmarkPanel.jsx
@@ -5,8 +5,8 @@ import React from 'react'
 export default React.createClass({
   render () {
     return <div className="BenchmarkPanel"
-      onClick={this.handleInteraction}
-      onTouchStart={this.handleInteraction}>
+      onClick={() => this.handleInteraction()}
+      onTouchStart={() => this.handleInteraction()}>
       {
         this.state.show
         ? (

--- a/src/devtools/ui/BenchmarkPanel.jsx
+++ b/src/devtools/ui/BenchmarkPanel.jsx
@@ -11,7 +11,7 @@ export default class BenchmarkPanel extends React.Component {
     }
   }
 
-  render() {
+  render () {
     return <div className="BenchmarkPanel"
       onClick={this.handleInteraction}
       onTouchStart={this.handleInteraction}>
@@ -28,7 +28,7 @@ export default class BenchmarkPanel extends React.Component {
     </div>
   }
 
-  componentDidMount() {
+  componentDidMount () {
     setInterval(() => this.forceUpdate(), 1000)
   }
 

--- a/src/devtools/ui/BenchmarkPanel.jsx
+++ b/src/devtools/ui/BenchmarkPanel.jsx
@@ -2,11 +2,19 @@
 import './BenchmarkPanel.scss'
 import React from 'react'
 
-export default React.createClass({
-  render () {
+export default class extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      show: false,
+      text: 'wow',
+    }
+  }
+
+  render() {
     return <div className="BenchmarkPanel"
-      onClick={() => this.handleInteraction()}
-      onTouchStart={() => this.handleInteraction()}>
+      onClick={this.handleInteraction}
+      onTouchStart={this.handleInteraction}>
       {
         this.state.show
         ? (
@@ -18,11 +26,13 @@ export default React.createClass({
         : 'Show Benchmark Stats'
       }
     </div>
-  },
-  componentDidMount () {
+  }
+
+  componentDidMount() {
     setInterval(() => this.forceUpdate(), 1000)
-  },
-  renderTable () {
+  }
+
+  renderTable = () => {
     let stats = this.props.bench.stats
     return <table>
       <tbody>
@@ -35,16 +45,11 @@ export default React.createClass({
         })}
       </tbody>
     </table>
-  },
-  getInitialState () {
-    return {
-      show: false,
-      text: 'wow',
-    }
-  },
-  handleInteraction (e) {
+  };
+
+  handleInteraction = (e) => {
     e.preventDefault()
     e.stopPropagation()
     this.setState({ show: !this.state.show })
-  }
-})
+  };
+}

--- a/src/flux/index.js
+++ b/src/flux/index.js
@@ -57,26 +57,31 @@ function toProperty (store) {
 
 export const connect = (props川) => (Component) => {
   let propsProperty = toProperty(props川)
-  return React.createClass({
-    getInitialState () {
+  return class extends React.Component {
+    constructor(props) {
+      super(props)
       this._unsubscribe = propsProperty.onValue(this.handleValue)
       let initialValue
       const initialUnsubscribe = propsProperty.onValue(value => (initialValue = value))
       initialUnsubscribe()
-      return { value: initialValue }
-    },
-    componentWillUnmount () {
+      this.state = { value: initialValue }
+    }
+
+    componentWillUnmount() {
       this._mounted = false
       if (this._unsubscribe) this._unsubscribe()
-    },
-    componentDidMount () {
+    }
+
+    componentDidMount() {
       this._mounted = true
-    },
-    handleValue (value) {
+    }
+
+    handleValue = (value) => {
       if (this._mounted) this.setState({ value })
-    },
-    render () {
+    }
+
+    render() {
       return <Component {...(this.state.value || { })} {...this.props} />
     }
-  })
+  }
 }

--- a/src/flux/index.js
+++ b/src/flux/index.js
@@ -58,7 +58,7 @@ function toProperty (store) {
 export const connect = (props川) => (Component) => {
   let propsProperty = toProperty(props川)
   return class extends React.Component {
-    constructor(props) {
+    constructor (props) {
       super(props)
       this._unsubscribe = propsProperty.onValue(this.handleValue)
       let initialValue
@@ -67,12 +67,12 @@ export const connect = (props川) => (Component) => {
       this.state = { value: initialValue }
     }
 
-    componentWillUnmount() {
+    componentWillUnmount () {
       this._mounted = false
       if (this._unsubscribe) this._unsubscribe()
     }
 
-    componentDidMount() {
+    componentDidMount () {
       this._mounted = true
     }
 
@@ -80,7 +80,7 @@ export const connect = (props川) => (Component) => {
       if (this._mounted) this.setState({ value })
     }
 
-    render() {
+    render () {
       return <Component {...(this.state.value || { })} {...this.props} />
     }
   }

--- a/src/game/ui/GameShellScene.jsx
+++ b/src/game/ui/GameShellScene.jsx
@@ -86,7 +86,7 @@ class CustomChartSelector extends React.Component {
   };
 }
 
-export default class extends React.Component {
+export default class GameShellScene extends React.Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/game/ui/GameShellScene.jsx
+++ b/src/game/ui/GameShellScene.jsx
@@ -15,7 +15,7 @@ const CustomChartSelector = React.createClass({
             {files.map(file =>
               <li>
                 <a href="javascript://"
-                  onClick={this.handleItemClick(file)}
+                  onClick={() => this.handleItemClick(file)}
                   className={
                         c({ 'is-active':
                             file.resource === this.props.selectedResource })}>
@@ -27,7 +27,7 @@ const CustomChartSelector = React.createClass({
               this.props.selectedResource
               ? (
                 <li>
-                  <a href="javascript://" onClick={this.handleClear}>
+                  <a href="javascript://" onClick={() => this.handleClear()}>
                     Clear
                   </a>
                 </li>
@@ -86,8 +86,8 @@ export default React.createClass({
     let options = this.state.options
     return <div
       className="GameShellScene"
-      onDragOver={this.handleDragOver}
-      onDrop={this.handleDrop}>
+      onDragOver={() => this.handleDragOver()}
+      onDrop={() => this.handleDrop()}>
       <h1>Bemuse Game Shell</h1>
       <p>This tool is intended for developers testing the game.</p>
       <form onSubmit={this.submit}>
@@ -105,7 +105,7 @@ export default React.createClass({
             <CustomChartSelector
               ref="dropzone"
               selectedResource={options.resource}
-              onSelect={this.handleSelectFile} />
+              onSelect={() => this.handleSelectFile()} />
           </label>
         </div>
         <div className="text">

--- a/src/game/ui/GameShellScene.jsx
+++ b/src/game/ui/GameShellScene.jsx
@@ -4,8 +4,15 @@ import React        from 'react'
 import DndResources from 'bemuse/resources/dnd-resources'
 import c            from 'classnames'
 
-const CustomChartSelector = React.createClass({
-  render () {
+class CustomChartSelector extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      files: [],
+    }
+  }
+
+  render() {
     let files = this.state.files
     return <div className="drop-zone">
       {
@@ -15,7 +22,7 @@ const CustomChartSelector = React.createClass({
             {files.map(file =>
               <li>
                 <a href="javascript://"
-                  onClick={() => this.handleItemClick(file)}
+                  onClick={this.handleItemClick}
                   className={
                         c({ 'is-active':
                             file.resource === this.props.selectedResource })}>
@@ -27,7 +34,7 @@ const CustomChartSelector = React.createClass({
               this.props.selectedResource
               ? (
                 <li>
-                  <a href="javascript://" onClick={() => this.handleClear()}>
+                  <a href="javascript://" onClick={this.handleClear}>
                     Clear
                   </a>
                 </li>
@@ -45,13 +52,9 @@ const CustomChartSelector = React.createClass({
         )
       }
     </div>
-  },
-  getInitialState () {
-    return {
-      files: [],
-    }
-  },
-  handleDrop (e) {
+  }
+
+  handleDrop = (e) => {
     e.preventDefault()
     let event = e.nativeEvent
     let resources = new DndResources(event)
@@ -70,24 +73,33 @@ const CustomChartSelector = React.createClass({
       }
     })
     .done()
-  },
-  handleItemClick (file) {
+  };
+
+  handleItemClick = (file) => {
     return () => {
       this.props.onSelect(this.state.resources, file.resource)
     }
-  },
-  handleClear () {
-    this.props.onSelect(null, null)
-  },
-})
+  };
 
-export default React.createClass({
-  render () {
+  handleClear = () => {
+    this.props.onSelect(null, null)
+  };
+}
+
+export default class extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      options: this.props.options,
+    }
+  }
+
+  render() {
     let options = this.state.options
     return <div
       className="GameShellScene"
-      onDragOver={() => this.handleDragOver()}
-      onDrop={() => this.handleDrop()}>
+      onDragOver={this.handleDragOver}
+      onDrop={this.handleDrop}>
       <h1>Bemuse Game Shell</h1>
       <p>This tool is intended for developers testing the game.</p>
       <form onSubmit={this.submit}>
@@ -105,7 +117,7 @@ export default React.createClass({
             <CustomChartSelector
               ref="dropzone"
               selectedResource={options.resource}
-              onSelect={() => this.handleSelectFile()} />
+              onSelect={this.handleSelectFile} />
           </label>
         </div>
         <div className="text">
@@ -137,33 +149,33 @@ export default React.createClass({
         <button type="submit">Play</button>
       </form>
     </div>
-  },
-  submit (e) {
+  }
+
+  submit = (e) => {
     e.preventDefault()
     this.props.play(this.state.options)
-  },
-  getInitialState () {
-    return {
-      options: this.props.options,
-    }
-  },
-  bindOption (binder) {
+  };
+
+  bindOption = (binder) => {
     return (event) => {
       binder(this.state.options, event.target.value)
       this.forceUpdate()
     }
-  },
-  handleDragOver (e) {
+  };
+
+  handleDragOver = (e) => {
     e.preventDefault()
-  },
-  handleDrop (e) {
+  };
+
+  handleDrop = (e) => {
     e.preventDefault()
     this.refs.dropzone.handleDrop(e)
-  },
-  handleSelectFile (resources, resource) {
+  };
+
+  handleSelectFile = (resources, resource) => {
     this.setState({
       options: Object.assign(this.state.options, { resources, resource })
     })
     this.forceUpdate()
-  },
-})
+  };
+}

--- a/src/game/ui/GameShellScene.jsx
+++ b/src/game/ui/GameShellScene.jsx
@@ -5,14 +5,14 @@ import DndResources from 'bemuse/resources/dnd-resources'
 import c            from 'classnames'
 
 class CustomChartSelector extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
     this.state = {
       files: [],
     }
   }
 
-  render() {
+  render () {
     let files = this.state.files
     return <div className="drop-zone">
       {
@@ -87,7 +87,7 @@ class CustomChartSelector extends React.Component {
 }
 
 export default class GameShellScene extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
     this.state = {
       options: this.props.options,

--- a/src/game/ui/GameShellScene.jsx
+++ b/src/game/ui/GameShellScene.jsx
@@ -94,7 +94,7 @@ export default class GameShellScene extends React.Component {
     }
   }
 
-  render() {
+  render () {
     let options = this.state.options
     return <div
       className="GameShellScene"

--- a/src/game/ui/LoadingScene.jsx
+++ b/src/game/ui/LoadingScene.jsx
@@ -9,15 +9,15 @@ import Scene from 'bemuse/ui/Scene.jsx'
 import LoadingSceneSongInfo from './LoadingSceneSongInfo.jsx'
 import LoadingSceneProgress from './LoadingSceneProgress.jsx'
 
-export default React.createClass({
-  propTypes: {
+export default class LoadingScene extends React.Component {
+  static propTypes = {
     song: PropTypes.object,
     tasks: PropTypes.array,
     eyecatchImagePromise: PropTypes.object,
     registerTeardownCallback: PropTypes.func,
-  },
+  }
 
-  render () {
+  render() {
     return <Scene className="LoadingScene" ref="scene">
       <div className="LoadingSceneのimage" ref="eyecatch"></div>
       <div className="LoadingSceneのinfo">
@@ -27,9 +27,9 @@ export default React.createClass({
       <div className="LoadingSceneのflash"></div>
       <div className="LoadingSceneのcover"></div>
     </Scene>
-  },
+  }
 
-  componentDidMount () {
+  componentDidMount() {
     if (this.props.eyecatchImagePromise) {
       this.props.eyecatchImagePromise.then(image => {
         ReactDOM.findDOMNode(this.refs.eyecatch).appendChild(image)
@@ -39,5 +39,5 @@ export default React.createClass({
       ReactDOM.findDOMNode(this.refs.scene).classList.add('is-exiting')
       return Promise.delay(500)
     })
-  },
-})
+  }
+}

--- a/src/game/ui/LoadingScene.jsx
+++ b/src/game/ui/LoadingScene.jsx
@@ -12,7 +12,7 @@ import LoadingSceneProgress from './LoadingSceneProgress.jsx'
 export default class LoadingScene extends React.Component {
   static propTypes = {
     song: PropTypes.object,
-    tasks: PropTypes.array,
+    tasks: PropTypes.object,
     eyecatchImagePromise: PropTypes.object,
     registerTeardownCallback: PropTypes.func,
   }

--- a/src/game/ui/LoadingScene.jsx
+++ b/src/game/ui/LoadingScene.jsx
@@ -17,7 +17,7 @@ export default class LoadingScene extends React.Component {
     registerTeardownCallback: PropTypes.func,
   }
 
-  render() {
+  render () {
     return <Scene className="LoadingScene" ref="scene">
       <div className="LoadingSceneのimage" ref="eyecatch"></div>
       <div className="LoadingSceneのinfo">
@@ -29,7 +29,7 @@ export default class LoadingScene extends React.Component {
     </Scene>
   }
 
-  componentDidMount() {
+  componentDidMount () {
     if (this.props.eyecatchImagePromise) {
       this.props.eyecatchImagePromise.then(image => {
         ReactDOM.findDOMNode(this.refs.eyecatch).appendChild(image)

--- a/src/game/ui/LoadingSceneProgress.jsx
+++ b/src/game/ui/LoadingSceneProgress.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 import LoadingSceneProgressBar from './LoadingSceneProgressBar.jsx'
 
 export default class LoadingSceneProgress extends React.Component {
-  render() {
+  render () {
     return <div className="LoadingSceneProgress">
       {this.props.tasks.value.map(task => this.renderItem(task))}
     </div>
@@ -21,11 +21,11 @@ export default class LoadingSceneProgress extends React.Component {
     </div>
   };
 
-  componentDidMount() {
+  componentDidMount () {
     this._unsubscribe = this.props.tasks.watch(() => this.forceUpdate())
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     this._unsubscribe()
   }
 }

--- a/src/game/ui/LoadingSceneProgress.jsx
+++ b/src/game/ui/LoadingSceneProgress.jsx
@@ -4,7 +4,7 @@ import './LoadingSceneProgress.scss'
 import React from 'react'
 import LoadingSceneProgressBar from './LoadingSceneProgressBar.jsx'
 
-export default class LoadingSceneProgressBar extends React.Component {
+export default class LoadingSceneProgress extends React.Component {
   render() {
     return <div className="LoadingSceneProgress">
       {this.props.tasks.value.map(task => this.renderItem(task))}

--- a/src/game/ui/LoadingSceneProgress.jsx
+++ b/src/game/ui/LoadingSceneProgress.jsx
@@ -4,13 +4,14 @@ import './LoadingSceneProgress.scss'
 import React from 'react'
 import LoadingSceneProgressBar from './LoadingSceneProgressBar.jsx'
 
-export default React.createClass({
-  render () {
+export default class LoadingSceneProgressBar extends React.Component {
+  render() {
     return <div className="LoadingSceneProgress">
       {this.props.tasks.value.map(task => this.renderItem(task))}
     </div>
-  },
-  renderItem ({ text, progressText, progress }) {
+  }
+
+  renderItem = ({ text, progressText, progress }) => {
     let width = Math.round((progress * 100) || 0) + '%'
     let extra = progressText ? ` (${progressText})` : ''
     return <div className="LoadingSceneProgressのitem">
@@ -18,11 +19,13 @@ export default React.createClass({
       {text}
       <span className="LoadingSceneProgressのextra">{extra}</span>
     </div>
-  },
-  componentDidMount () {
+  };
+
+  componentDidMount() {
     this._unsubscribe = this.props.tasks.watch(() => this.forceUpdate())
-  },
-  componentWillUnmount () {
+  }
+
+  componentWillUnmount() {
     this._unsubscribe()
-  },
-})
+  }
+}

--- a/src/game/ui/LoadingSceneProgress.jsx
+++ b/src/game/ui/LoadingSceneProgress.jsx
@@ -14,7 +14,7 @@ export default class LoadingSceneProgress extends React.Component {
   renderItem = ({ text, progressText, progress }) => {
     let width = Math.round((progress * 100) || 0) + '%'
     let extra = progressText ? ` (${progressText})` : ''
-    return <div className="LoadingSceneProgressのitem">
+    return <div key={text} className="LoadingSceneProgressのitem">
       <LoadingSceneProgressBar width={width} />
       {text}
       <span className="LoadingSceneProgressのextra">{extra}</span>

--- a/src/game/ui/LoadingSceneProgressBar.jsx
+++ b/src/game/ui/LoadingSceneProgressBar.jsx
@@ -3,7 +3,7 @@ import './LoadingSceneProgressBar.scss'
 import React from 'react'
 
 export default class LoadingSceneProgressBar extends React.Component {
-  render() {
+  render () {
     return <div className="LoadingSceneProgressBar">
       <div
         className="LoadingSceneProgressBarのbar"

--- a/src/game/ui/LoadingSceneProgressBar.jsx
+++ b/src/game/ui/LoadingSceneProgressBar.jsx
@@ -2,12 +2,12 @@
 import './LoadingSceneProgressBar.scss'
 import React from 'react'
 
-export default React.createClass({
-  render () {
+export default class LoadingSceneProgressBar extends React.Component {
+  render() {
     return <div className="LoadingSceneProgressBar">
       <div
         className="LoadingSceneProgressBarのbar"
         style={{ width: this.props.width }}></div>
     </div>
   }
-})
+}

--- a/src/game/ui/LoadingSceneSongInfo.jsx
+++ b/src/game/ui/LoadingSceneSongInfo.jsx
@@ -4,9 +4,8 @@ import './LoadingSceneSongInfo.scss'
 import React from 'react'
 import { isTitleDisplayMode } from 'bemuse/devtools/query-flags'
 
-export default React.createClass({
-
-  render () {
+export default class LoadingSceneSongInfo extends React.Component {
+  render() {
     const song = this.props.song
     return <div className="LoadingSceneSongInfo">
       <div className="LoadingSceneSongInfoのgenre">{song.genre}</div>
@@ -22,5 +21,4 @@ export default React.createClass({
         <div className="LoadingSceneSongInfoのsubartist">{text}</div>)}
     </div>
   }
-
-})
+}

--- a/src/game/ui/LoadingSceneSongInfo.jsx
+++ b/src/game/ui/LoadingSceneSongInfo.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { isTitleDisplayMode } from 'bemuse/devtools/query-flags'
 
 export default class LoadingSceneSongInfo extends React.Component {
-  render() {
+  render () {
     const song = this.props.song
     return <div className="LoadingSceneSongInfo">
       <div className="LoadingSceneSongInfoのgenre">{song.genre}</div>

--- a/src/game/ui/LoadingSceneSongInfo.jsx
+++ b/src/game/ui/LoadingSceneSongInfo.jsx
@@ -12,13 +12,13 @@ export default class LoadingSceneSongInfo extends React.Component {
       <div className="LoadingSceneSongInfoのtitle">{song.title}</div>
       {!isTitleDisplayMode()
         ? song.subtitles.map(text =>
-          <div className="LoadingSceneSongInfoのsubtitle">{text}</div>
+          <div key={text} className="LoadingSceneSongInfoのsubtitle">{text}</div>
         )
         : null
       }
       <div className="LoadingSceneSongInfoのartist">{song.artist}</div>
       {song.subartists.map(text =>
-        <div className="LoadingSceneSongInfoのsubartist">{text}</div>)}
+        <div key={text} className="LoadingSceneSongInfoのsubartist">{text}</div>)}
     </div>
   }
 }

--- a/src/online/ui/AuthenticationForm.jsx
+++ b/src/online/ui/AuthenticationForm.jsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom'
 import OptionsButton from 'bemuse/app/ui/OptionsButton'
 import $ from 'jquery'
 
-export default class extends React.Component {
+export default class AuthenticationForm extends React.Component {
   onButtonClick = (e) => {
     e.preventDefault()
     this.props.onSubmit({

--- a/src/online/ui/AuthenticationForm.jsx
+++ b/src/online/ui/AuthenticationForm.jsx
@@ -16,13 +16,13 @@ export default class AuthenticationForm extends React.Component {
     })
   };
 
-  componentDidMount() {
+  componentDidMount () {
     $(ReactDOM.findDOMNode(this)).on('keydown keyup keypress', (e) => {
       e.stopPropagation()
     })
   }
 
-  render() {
+  render () {
     return <form className="AuthenticationForm">
       <div className="AuthenticationFormのgroup">
         <label>

--- a/src/online/ui/AuthenticationForm.jsx
+++ b/src/online/ui/AuthenticationForm.jsx
@@ -5,8 +5,8 @@ import ReactDOM from 'react-dom'
 import OptionsButton from 'bemuse/app/ui/OptionsButton'
 import $ from 'jquery'
 
-export default React.createClass({
-  onButtonClick (e) {
+export default class extends React.Component {
+  onButtonClick = (e) => {
     e.preventDefault()
     this.props.onSubmit({
       username:             ReactDOM.findDOMNode(this.refs.username).value,
@@ -14,13 +14,15 @@ export default React.createClass({
       passwordConfirmation: ReactDOM.findDOMNode(this.refs.passwordConfirmation).value,
       email:                ReactDOM.findDOMNode(this.refs.email).value,
     })
-  },
-  componentDidMount () {
+  };
+
+  componentDidMount() {
     $(ReactDOM.findDOMNode(this)).on('keydown keyup keypress', (e) => {
       e.stopPropagation()
     })
-  },
-  render () {
+  }
+
+  render() {
     return <form className="AuthenticationForm">
       <div className="AuthenticationFormのgroup">
         <label>
@@ -52,8 +54,9 @@ export default React.createClass({
         </div>
       </div>
     </form>
-  },
-  renderSubmitText () {
+  }
+
+  renderSubmitText = () => {
     return this.props.mode === 'signUp' ? 'Sign Me Up' : 'Log In'
-  },
-})
+  };
+}

--- a/src/online/ui/AuthenticationPanel.jsx
+++ b/src/online/ui/AuthenticationPanel.jsx
@@ -114,7 +114,7 @@ export default class AuthenticationPanel extends React.Component {
     this.setState({ mode: 'signUp' })
   }
 
-  render() {
+  render () {
     return <div className="AuthenticationPanel">
       <Panel title="Bemuse Online Ranking">
         <div className="AuthenticationPanelのlayout">

--- a/src/online/ui/AuthenticationPanel.jsx
+++ b/src/online/ui/AuthenticationPanel.jsx
@@ -10,7 +10,7 @@ import online from 'bemuse/online/instance'
 
 import AuthenticationForm from './AuthenticationForm'
 
-export default class extends React.Component {
+export default class AuthenticationPanel extends React.Component {
   constructor (props) {
     super(props)
     this.state = {

--- a/src/online/ui/AuthenticationPanel.jsx
+++ b/src/online/ui/AuthenticationPanel.jsx
@@ -10,24 +10,27 @@ import online from 'bemuse/online/instance'
 
 import AuthenticationForm from './AuthenticationForm'
 
-export default React.createClass({
-  getInitialState () {
-    return {
+export default class extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
       mode: 'logIn',
       authentication: {
         status: 'idle',
         message: ''
       }
     }
-  },
-  onSubmit (formData) {
+  }
+
+  onSubmit = (formData) => {
     if (this.state.mode === 'signUp') {
       this.runPromise(this.doSignUp(formData))
     } else {
       this.runPromise(this.doLogIn(formData))
     }
-  },
-  runPromise (promise) {
+  }
+
+  runPromise = (promise) => {
     this.setState({
       authentication: {
         status: 'loading',
@@ -53,8 +56,9 @@ export default React.createClass({
       }
     )
     .done()
-  },
-  doSignUp (formData) {
+  }
+
+  doSignUp = (formData) => {
     return Promise.try(() => {
       if (!formData.username.trim()) {
         throw new Error('Please enter a username.')
@@ -85,8 +89,9 @@ export default React.createClass({
         return 'Welcome to Bemuse!'
       })
     })
-  },
-  doLogIn (formData) {
+  }
+
+  doLogIn = (formData) => {
     return Promise.try(() => {
       if (!formData.username.trim()) {
         throw new Error('Please enter your username.')
@@ -99,14 +104,17 @@ export default React.createClass({
         return 'Welcome back!'
       })
     })
-  },
-  onSwitchToLogin () {
+  }
+
+  onSwitchToLogin = () => {
     this.setState({ mode: 'logIn' })
-  },
-  onSwitchToSignup () {
+  }
+
+  onSwitchToSignup = () => {
     this.setState({ mode: 'signUp' })
-  },
-  render () {
+  }
+
+  render() {
     return <div className="AuthenticationPanel">
       <Panel title="Bemuse Online Ranking">
         <div className="AuthenticationPanelのlayout">
@@ -140,15 +148,17 @@ export default React.createClass({
         </div>
       </Panel>
     </div>
-  },
-  renderMessage () {
+  }
+
+  renderMessage = () => {
     let state = this.state.authentication
     if (state.status === 'idle' || !state.message) return null
     return <div className={c('AuthenticationPanelのmessage', 'is-' + state.status)}>
       {state.message}
     </div>
-  },
-  renderModeActiveClass (mode) {
+  }
+
+  renderModeActiveClass = (mode) => {
     return mode === this.state.mode ? 'is-active' : ''
-  },
-})
+  }
+}

--- a/src/online/ui/AuthenticationPopup.jsx
+++ b/src/online/ui/AuthenticationPopup.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import ModalPopup from 'bemuse/ui/ModalPopup'
 import AuthenticationPanel from './AuthenticationPanel'
 
-export default class extends React.Component {
+export default class AuthenticationPopup extends React.Component {
   render() {
     return <ModalPopup {...this.props}>
       <div className="AuthenticationPopup">

--- a/src/online/ui/AuthenticationPopup.jsx
+++ b/src/online/ui/AuthenticationPopup.jsx
@@ -5,7 +5,7 @@ import ModalPopup from 'bemuse/ui/ModalPopup'
 import AuthenticationPanel from './AuthenticationPanel'
 
 export default class AuthenticationPopup extends React.Component {
-  render() {
+  render () {
     return <ModalPopup {...this.props}>
       <div className="AuthenticationPopup">
         <AuthenticationPanel onFinish={this.props.onFinish} />

--- a/src/online/ui/AuthenticationPopup.jsx
+++ b/src/online/ui/AuthenticationPopup.jsx
@@ -4,12 +4,12 @@ import React from 'react'
 import ModalPopup from 'bemuse/ui/ModalPopup'
 import AuthenticationPanel from './AuthenticationPanel'
 
-export default React.createClass({
-  render () {
+export default class extends React.Component {
+  render() {
     return <ModalPopup {...this.props}>
       <div className="AuthenticationPopup">
         <AuthenticationPanel onFinish={this.props.onFinish} />
       </div>
     </ModalPopup>
   }
-})
+}

--- a/src/ui/Flex.jsx
+++ b/src/ui/Flex.jsx
@@ -2,7 +2,7 @@
 import React from 'react'
 
 export default class Flex extends React.Component {
-  render() {
+  render () {
     let style = { }
     if (this.props.grow !== undefined) style.flex = this.props.grow
     return <div style={style}></div>

--- a/src/ui/Flex.jsx
+++ b/src/ui/Flex.jsx
@@ -1,10 +1,10 @@
 
 import React from 'react'
 
-export default React.createClass({
-  render () {
+export default class Flex extends React.Component {
+  render() {
     let style = { }
     if (this.props.grow !== undefined) style.flex = this.props.grow
     return <div style={style}></div>
   }
-})
+}

--- a/src/ui/Loading.jsx
+++ b/src/ui/Loading.jsx
@@ -3,7 +3,7 @@ import './Loading.scss'
 import React from 'react'
 
 export default class Loading extends React.Component {
-  render() {
+  render () {
     return <div className="Loading">
       <div className="Loadingのdj"></div>
       <div className="Loadingのtext">Loading</div>

--- a/src/ui/Loading.jsx
+++ b/src/ui/Loading.jsx
@@ -2,11 +2,11 @@
 import './Loading.scss'
 import React from 'react'
 
-export default React.createClass({
-  render () {
+export default class Loading extends React.Component {
+  render() {
     return <div className="Loading">
       <div className="Loadingのdj"></div>
       <div className="Loadingのtext">Loading</div>
     </div>
   }
-})
+}

--- a/src/ui/Markdown.jsx
+++ b/src/ui/Markdown.jsx
@@ -17,11 +17,11 @@ const safeMarkdown = new Markdown({
 })
 
 export default class MarkdownContent extends React.Component {
-  render() {
+  render () {
     return <article className="Markdown" dangerouslySetInnerHTML={this.renderHTML()}></article>
   }
 
-  componentDidMount() {
+  componentDidMount () {
     ReactDOM.findDOMNode(this).addEventListener('click', e => {
       e.preventDefault()
       if (e.target.href) {

--- a/src/ui/Markdown.jsx
+++ b/src/ui/Markdown.jsx
@@ -16,7 +16,7 @@ const safeMarkdown = new Markdown({
   typographer: true,
 })
 
-export default class Markdown extends React.Component {
+export default class MarkdownContent extends React.Component {
   render() {
     return <article className="Markdown" dangerouslySetInnerHTML={this.renderHTML()}></article>
   }

--- a/src/ui/Markdown.jsx
+++ b/src/ui/Markdown.jsx
@@ -16,20 +16,22 @@ const safeMarkdown = new Markdown({
   typographer: true,
 })
 
-export default React.createClass({
-  render () {
+export default class Markdown extends React.Component {
+  render() {
     return <article className="Markdown" dangerouslySetInnerHTML={this.renderHTML()}></article>
-  },
-  componentDidMount () {
+  }
+
+  componentDidMount() {
     ReactDOM.findDOMNode(this).addEventListener('click', e => {
       e.preventDefault()
       if (e.target.href) {
         window.open(e.target.href, '_blank')
       }
     })
-  },
-  renderHTML () {
+  }
+
+  renderHTML = () => {
     const html = (this.props.safe ? safeMarkdown : markdown).render(this.props.source)
     return { __html: html }
-  },
-})
+  }
+}

--- a/src/ui/ModalPopup.jsx
+++ b/src/ui/ModalPopup.jsx
@@ -5,7 +5,7 @@ import c            from 'classnames'
 import { WarpPortal } from '../react-warp'
 
 export default class ModalPopup extends React.Component {
-  render() {
+  render () {
     if (this.props.visible === false) return null
     return <WarpPortal content={
       <div className={c('ModalPopup',

--- a/src/ui/ModalPopup.jsx
+++ b/src/ui/ModalPopup.jsx
@@ -4,8 +4,8 @@ import React        from 'react'
 import c            from 'classnames'
 import { WarpPortal } from '../react-warp'
 
-export default React.createClass({
-  render () {
+export default class ModalPopup extends React.Component {
+  render() {
     if (this.props.visible === false) return null
     return <WarpPortal content={
       <div className={c('ModalPopup',
@@ -20,4 +20,4 @@ export default React.createClass({
       <span style={{ display: 'none' }}></span>
     </WarpPortal>
   }
-})
+}

--- a/src/ui/Panel.jsx
+++ b/src/ui/Panel.jsx
@@ -3,11 +3,11 @@ import './Panel.scss'
 import React from 'react'
 import c from 'classnames'
 
-export default React.createClass({
-  render () {
+export default class Panel extends React.Component {
+  render() {
     return <div className={c('Panel', this.props.className)}>
       <div className="Panelのtitle">{this.props.title}</div>
       <div className="Panelのcontent">{this.props.children}</div>
     </div>
   }
-})
+}

--- a/src/ui/Panel.jsx
+++ b/src/ui/Panel.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import c from 'classnames'
 
 export default class Panel extends React.Component {
-  render() {
+  render () {
     return <div className={c('Panel', this.props.className)}>
       <div className="Panelのtitle">{this.props.title}</div>
       <div className="Panelのcontent">{this.props.children}</div>

--- a/src/ui/RunningNumber.jsx
+++ b/src/ui/RunningNumber.jsx
@@ -5,11 +5,11 @@ import ReactDOM from 'react-dom'
 import now      from 'bemuse/utils/now'
 
 export default class RunningNumber extends React.Component {
-  render() {
+  render () {
     return <span className="RunningNumber"></span>
   }
 
-  componentDidMount() {
+  componentDidMount () {
     let node = ReactDOM.findDOMNode(this)
     let text = document.createTextNode('')
     node.appendChild(text)

--- a/src/ui/RunningNumber.jsx
+++ b/src/ui/RunningNumber.jsx
@@ -4,11 +4,12 @@ import React    from 'react'
 import ReactDOM from 'react-dom'
 import now      from 'bemuse/utils/now'
 
-export default React.createClass({
-  render () {
+export default class RunningNumber extends React.Component {
+  render() {
     return <span className="RunningNumber"></span>
-  },
-  componentDidMount () {
+  }
+
+  componentDidMount() {
     let node = ReactDOM.findDOMNode(this)
     let text = document.createTextNode('')
     node.appendChild(text)
@@ -22,9 +23,10 @@ export default React.createClass({
         clearInterval(interval)
       }
     }, 16)
-  },
-  _getText (value) {
+  }
+
+  _getText = (value) => {
     if (this.props.formatter) return this.props.formatter(value)
     return value.toFixed(0)
-  },
-})
+  }
+}

--- a/src/ui/Scene.jsx
+++ b/src/ui/Scene.jsx
@@ -4,13 +4,14 @@ import c from 'classnames'
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default React.createClass({
-  propTypes: {
+export default class Scene extends React.Component {
+  static propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
     onDragEnter: PropTypes.func
-  },
-  render () {
+  };
+
+  render() {
     return <div
       className={c('Scene', this.props.className)}
       onDragEnter={this.props.onDragEnter}
@@ -18,4 +19,4 @@ export default React.createClass({
       {this.props.children}
     </div>
   }
-})
+}

--- a/src/ui/Scene.jsx
+++ b/src/ui/Scene.jsx
@@ -9,9 +9,9 @@ export default class Scene extends React.Component {
     className: PropTypes.string,
     children: PropTypes.node,
     onDragEnter: PropTypes.func
-  };
+  }
 
-  render() {
+  render () {
     return <div
       className={c('Scene', this.props.className)}
       onDragEnter={this.props.onDragEnter}

--- a/src/ui/SceneHeading.jsx
+++ b/src/ui/SceneHeading.jsx
@@ -5,7 +5,7 @@ import React  from 'react'
 import c      from 'classnames'
 
 export default class SceneHeading extends React.Component {
-  render() {
+  render () {
     return <div className={c('SceneHeading', this.props.className)}>
       {this.props.children}
     </div>

--- a/src/ui/SceneHeading.jsx
+++ b/src/ui/SceneHeading.jsx
@@ -4,12 +4,10 @@ import './SceneHeading.scss'
 import React  from 'react'
 import c      from 'classnames'
 
-export default React.createClass({
-
-  render () {
+export default class SceneHeading extends React.Component {
+  render() {
     return <div className={c('SceneHeading', this.props.className)}>
       {this.props.children}
     </div>
   }
-
-})
+}

--- a/src/ui/SceneToolbar.jsx
+++ b/src/ui/SceneToolbar.jsx
@@ -2,18 +2,18 @@
 import './SceneToolbar.scss'
 import React from 'react'
 
-export const SceneToolbar = React.createClass({
-  render () {
+export class SceneToolbar extends React.Component {
+  render() {
     return <div className="SceneToolbar">
       {this.props.children}
     </div>
   }
-})
+}
 
-SceneToolbar.Spacer = React.createClass({
-  render () {
+SceneToolbar.Spacer = class SceneToolbarSpacer extends React.Component {
+  render() {
     return <div className="SceneToolbarのspacer"></div>
   }
-})
+}
 
 export default SceneToolbar

--- a/src/ui/SceneToolbar.jsx
+++ b/src/ui/SceneToolbar.jsx
@@ -3,7 +3,7 @@ import './SceneToolbar.scss'
 import React from 'react'
 
 export class SceneToolbar extends React.Component {
-  render() {
+  render () {
     return <div className="SceneToolbar">
       {this.props.children}
     </div>
@@ -11,7 +11,7 @@ export class SceneToolbar extends React.Component {
 }
 
 SceneToolbar.Spacer = class SceneToolbarSpacer extends React.Component {
-  render() {
+  render () {
     return <div className="SceneToolbarのspacer"></div>
   }
 }

--- a/src/ui/YouTube.jsx
+++ b/src/ui/YouTube.jsx
@@ -3,24 +3,28 @@ import './YouTube.scss'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-export default React.createClass({
-  render () {
+export default class extends React.Component {
+  render() {
     return <iframe width="100%" className="YouTube"
       src={this.getUrl()} frameBorder="0" allowFullScreen></iframe>
-  },
-  getUrl () {
+  }
+
+  getUrl = () => {
     return 'https://www.youtube.com/embed/' +
         this.props.url.match(/v=([^&]+)/)[1]
-  },
-  componentDidMount () {
+  }
+
+  componentDidMount() {
     window.addEventListener('resize', this.handleResize)
     this.handleResize()
-  },
-  componentWillUnmount () {
+  }
+
+  componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize)
-  },
-  handleResize () {
+  }
+
+  handleResize = () => {
     let el = ReactDOM.findDOMNode(this)
     el.style.height = el.offsetWidth * 9 / 16 + 'px'
-  },
-})
+  }
+}

--- a/src/ui/YouTube.jsx
+++ b/src/ui/YouTube.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 export default class extends React.Component {
-  render() {
+  render () {
     return <iframe width="100%" className="YouTube"
       src={this.getUrl()} frameBorder="0" allowFullScreen></iframe>
   }

--- a/src/ui/YouTube.jsx
+++ b/src/ui/YouTube.jsx
@@ -14,12 +14,12 @@ export default class extends React.Component {
         this.props.url.match(/v=([^&]+)/)[1]
   }
 
-  componentDidMount() {
+  componentDidMount () {
     window.addEventListener('resize', this.handleResize)
     this.handleResize()
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     window.removeEventListener('resize', this.handleResize)
   }
 


### PR DESCRIPTION
Reference: #437.

Note that this will most likely give out CI errors in the first place, hence the [WIP] tag.

### Known issues

* ~~Some `PropTypes` checks fail (e.g. in `MusicSelectPreviewer`), therefore song previews don't currently load~~ This actually works now.

### Other notable changes

* Converted some components with `recompose/pure` mixins to `React.PureComponent`
* Changed some createClass components to SFCs
* Fixed incorrect `PropTypes`.
* Other minor tweaks + code cleanups, such as addign `key` attributes for any iterated elements.