### PR TITLE
Fixing `npm test` command after npm tasks changes

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -24,7 +24,7 @@ function generateBaseConfig () {
     module: {
       loaders: generateLoadersConfig(),
       noParse: [
-        /node_modules\/sinon\//,
+        /sinon\.js/,
       ],
     },
     plugins: [


### PR DESCRIPTION
Thanks to `sinon`, running tests locally results in this error.

![image](https://user-images.githubusercontent.com/5663877/31573373-6783b37e-b0e4-11e7-828c-6bdce70fe848.png)

After:

![image](https://user-images.githubusercontent.com/5663877/31573984-1e736e66-b0f0-11e7-8208-9daec7e9c19a.png)

reference: https://github.com/webpack-contrib/karma-webpack/issues/43