### PR TITLE
Updated Browserslist compatibility table

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -106,7 +106,6 @@ function generateLoadersConfig () {
             plugins: () => [
               require('postcss-flexbugs-fixes'),
               require('autoprefixer')({
-                browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1'],
                 flexbox: 'no-2009'
               })
             ]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "workspaces": [
     "website"
   ],
+  "browserslist": [
+    ">0.25%",
+    "not ie 11",
+    "not op_mini all"
+  ],
   "scripts": {
     "build": "gulp build",
     "build:ios": "cross-env NODE_ENV=ios gulp build",


### PR DESCRIPTION
As mentioned on [this blog post](https://jamie.build/last-2-versions), a usage-based compatibility table has a better representation and would prevent tools like Autoprefixer from unnecessarily compiling away things.

I've also moved the `browserslist` option to `package.json` so that
all packages that depend on it (e.g. Babel) could use it.

[See browserslist coverage](http://browserl.ist/?q=%3E0.25%25%2C+not+ie+11%2C+not+op_mini+all)