### PR TITLE
:building_construction: Don't register service worker in localhost

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -98,10 +98,7 @@ function getFirstScene () {
 }
 
 function shouldActivateServiceWorker () {
-  return (
-    (location.protocol === 'https:' && location.host === 'bemuse.ninja') ||
-    location.hostname === 'localhost'
-  )
+  return location.protocol === 'https:' && location.host === 'bemuse.ninja'
 }
 
 function setupServiceWorker () {


### PR DESCRIPTION
This prevents the inevitable fact that any other local apps that use the
same port as ours will be overriden by Bemuse's service worker.