### PR TITLE
Fix cross browser fullscreen support

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "redux": "^3.7.2",
     "reselect": "^2.5.1",
     "rxjs": "^5.5.12",
+    "screenfull": "^3.3.3",
     "test-bed": "^0.777.77-beta",
     "throat": "^2.0.2",
     "timesynchro": "^1.0.1",

--- a/src/game/display/index.js
+++ b/src/game/display/index.js
@@ -5,6 +5,7 @@ import $ from 'jquery'
 import PlayerDisplay from './player-display'
 import formatTime from '../../utils/formatTime'
 import { shouldDisableFullScreen } from 'bemuse/devtools/query-flags'
+import screenfull from 'screenfull'
 
 export class GameDisplay {
   constructor ({ game, context, backgroundImagePromise, video }) {
@@ -143,17 +144,14 @@ export class GameDisplay {
   }
 
   _createFullScreenButton () {
-    if (
-      shouldDisableFullScreen() ||
-      !document.documentElement.requestFullscreen
-    ) {
+    if (shouldDisableFullScreen() || !screenfull.enabled) {
       return
     }
     const touchButtons = document.createElement('div')
     touchButtons.className = 'game-display--touch-buttons is-visible is-right'
     this.wrapper.appendChild(touchButtons)
     const onClick = () => {
-      document.documentElement.requestFullscreen()
+      screenfull.request()
     }
     const button = createTouchButton(
       onClick,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12515,6 +12515,11 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+screenfull@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-3.3.3.tgz#8cf7e706aceac2e75131aadcb81b622acfe11d39"
+  integrity sha512-DzYUuXr+OV2BDvYXaYzlYgJd4WXZZ2CW5NFC7Kw6TUCpzXJAx4MwlVD6CH+Mu6fi8rfAQIQfqdFZ4jtDsEkWig==
+
 script-loader@^0.7.0, script-loader@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/script-loader/-/script-loader-0.7.2.tgz#2016db6f86f25f5cf56da38915d83378bb166ba7"


### PR DESCRIPTION
Reintroducing screenfull after its removal in 5234fb09, because fullscreen methods are still prefixed in at least one browser. E.g. the latest chrome has `document.webkitFullscreenEnabled`.

I tried the latest Chrome/Firefox versions, and both are working.

Fixes #497