### PR TITLE
Require correct prop-type in OptionsInputKeys

### DIFF
--- a/src/app/ui/OptionsInputKeys.jsx
+++ b/src/app/ui/OptionsInputKeys.jsx
@@ -6,7 +6,7 @@ import OptionsInputKey from './OptionsInputKey'
 
 class OptionsInputKeys extends React.PureComponent {
   static propTypes = {
-    texts: PropTypes.arrayOf(PropTypes.string),
+    texts: PropTypes.objectOf(PropTypes.string),
     editing: PropTypes.string,
     onEdit: PropTypes.func,
     keyboardMode: PropTypes.bool


### PR DESCRIPTION
An object like `{1: 'S', 2: 'D', ...}` is passed to `OptionsInputKeys`, but it expects an array, so it complained in development. By changing it to expect an object with string values instead, it stops complaining.