### PR TITLE
Mute music preview during calibration

### DIFF
--- a/src/auto-synchro/index.js
+++ b/src/auto-synchro/index.js
@@ -25,7 +25,15 @@ export function main () {
   const ConnectedExperimentScene = connect(state川)(ExperimentScene)
 
   const scene = React.createElement(ConnectedExperimentScene, {
-    onStart: () => play()
+    onStart: () => {
+      if (window.opener) {
+        window.opener.postMessage({ type: 'calibration-started' }, '*')
+        addEventListener('beforeunload', () => {
+          window.opener.postMessage({ type: 'calibration-closed' }, '*')
+        })
+      }
+      play()
+    }
   })
 
   ReactDOM.render(scene, $('<div></div>').appendTo('body')[0])

--- a/src/auto-synchro/index.js
+++ b/src/auto-synchro/index.js
@@ -26,19 +26,23 @@ export function main () {
 
   const scene = React.createElement(ConnectedExperimentScene, {
     onStart: () => {
-      if (window.opener) {
-        window.opener.postMessage({ type: 'calibration-started' }, '*')
-        addEventListener('beforeunload', () => {
-          window.opener.postMessage({ type: 'calibration-closed' }, '*')
-        })
-      }
       play()
+      postMessage({ type: 'calibration-started' })
+      addEventListener('beforeunload', () => {
+        postMessage({ type: 'calibration-closed' })
+      })
     }
   })
 
   ReactDOM.render(scene, $('<div></div>').appendTo('body')[0])
 
   let play
+
+  function postMessage (data) {
+    if (window.opener) {
+      window.opener.postMessage(data, '*')
+    }
+  }
 
   function getLatency (samples) {
     let data = samples.map(d => d[1])
@@ -63,14 +67,7 @@ export function main () {
         a () {
           let latency = Math.max(0, getLatency(samples))
           state口.push({ finished: true, latency })
-          if (window.opener) {
-            window.opener.postMessage(
-              {
-                latency: latency
-              },
-              '*'
-            )
-          }
+          postMessage({ latency: latency })
         }
       })
       let tap = () => {

--- a/src/music-previewer/MusicSelectPreviewer.jsx
+++ b/src/music-previewer/MusicSelectPreviewer.jsx
@@ -12,14 +12,23 @@ export default class MusicSelectPreviewer extends React.Component {
   componentDidMount () {
     MusicPreviewer.enable()
     MusicPreviewer.preview(this.props.url)
+    addEventListener('message', this.handleMessage)
   }
   componentWillUnmount () {
     MusicPreviewer.disable()
+    removeEventListener('message', this.handleMessage)
   }
   componentWillReceiveProps (nextProps) {
     MusicPreviewer.preview(nextProps.url)
   }
   render () {
     return null
+  }
+  handleMessage ({ data }) {
+    if (data.type === 'calibration-started') {
+      MusicPreviewer.disable()
+    } else if (data.type === 'calibration-closed') {
+      MusicPreviewer.enable()
+    }
   }
 }


### PR DESCRIPTION
Uses message events to inform the main window when calibration has started, and when the calibration window closes. Actual pausing/resuming is handled by the `MusicSelectPreviewer` component.

Fixes #449 