### PR TITLE
:memo: music server docs improvements

### DIFF
--- a/docs/music-server.md
+++ b/docs/music-server.md
@@ -240,6 +240,7 @@ PS> bemuse-tools pack 'Lapis - SHIKI'
 # Written metadata.json
 ```
 
+    If you pack bms files from <b>linux</b>, <code>-> Converting audio to m4a [for iOS and Safari]</code> will get errors because of codec. Converted pack will not play sounds on Apple platform devices.
 Now if you look at your song folder, you should see a new folder called **assets**:
 
     Lapis - SHIKI

--- a/docs/music-server.md
+++ b/docs/music-server.md
@@ -228,6 +228,14 @@ It should display the version:
       pack <path> — Packs sounds and BGAs into assets folder
       server <path> — Serves a Bemuse server (no indexing or conversion)
 
+If you installed bemuse-tools from yarn and get `command not found` error, you have to export path.
+
+```bash
+$ export PATH=~/.yarn/bin:${PATH}
+```
+
+and run once again for installation check.
+
 ## Creating Your Server Folder
 
 Extract your BMS files into a folder. One song per folder. For example:
@@ -412,28 +420,22 @@ Once the file is saved, open your XAMPP Control Pannel and run "Apache".
 
 Then connect to the music server with (http://bemuse.ninja/?server=https://localhost/).
 
-#### Linux or macOS using [Nginx](https://nginx.org/en/)
+#### macOS using [Nginx](https://nginx.org/en/)
 
 First, Open terminal and Use `cd` command, move to folder that bemuse custom files contained.
 
 Then, install Nginx
 
-from macOS:
 ```bash
 $ brew install nginx
 ```
+
 <div class="admonition note">
 <p class="admonition-title">Note</p>
 <p>
     Homebrew will install nginx on /usr/local.
-</p>
+</p
 </div>
-
-
-from Debian Linux:
-```bash
-$ sudo apt install nginx
-```
 
 Check your current location
 
@@ -441,35 +443,27 @@ Check your current location
 $ pwd
 # e.g Output: /Users/cenox/Dev/bemuse-test
 ```
-
 Memo output location. This will be used when config nginx.
 
 Go to nginx folder.
 
-from macOS:
 ```bash
 $ cd /usr/local/nginx/etc
 ```
 
-from Debian Linux:
-```bash
-$ cd /etc/nginx
-```
+Use `touch` command for making config file to serve bemuse files.
 
-Then, Use `touch` command to make setting files for serve bemuse files.
-
-from macOS:
 ```bash
 $ touch servers/bemuse
 ```
 
-from Debian Linux:
+Open bemuse setting file with text editor. This example uses `nano`.
+
 ```bash
-$ sudo touch sites-available/bemuse
+$ nano servers/bemuse
 ```
 
-Open bemuse setting file with text editor. This example uses `nano`. Write into setting file.
-
+Insert below text.
 
 ```nginx
 server {
@@ -487,14 +481,8 @@ Save file with `Control+X`, `Y`, `Enter`.
 
 Reload nginx
 
-from macOS:
 ```bash
 $ nginx -s reload
-```
-
-from Debian Linux:
-```bash
-$ sudo systemctl restart nginx
 ```
 
 Then connect to the music server with (http://bemuse.ninja/?server=http://localhost).
@@ -507,3 +495,72 @@ You can register service via brew. This makes nginx run when user logged in.
 ```bash
 $ brew services start nginx
 ```
+
+#### Debian Linux using [Nginx](https://nginx.org/en/)
+
+First, Open terminal and Use `cd` command, move to folder that bemuse custom files contained.
+
+Then, install Nginx
+
+```bash
+$ sudo apt install nginx
+```
+
+Check your current location
+
+```bash
+$ pwd
+# e.g Output: /home/cenox/bemuse-test
+```
+
+Memo output location. This will be used when config nginx.
+
+Go to nginx folder.
+
+```bash
+$ cd /etc/nginx
+```
+
+Use `touch` command for making config file to serve bemuse files.
+
+```bash
+$ sudo touch site-available/bemuse
+```
+
+Open bemuse setting file with text editor. This example uses `nano`.
+
+```bash
+$ sudo nano servers/bemuse
+```
+
+Insert below text.
+
+```nginx
+server {
+    listen 80;
+
+    server_name localhost;
+
+    location / {
+        add_header 'Access-Control-Allow-Origin' '*';
+        root /home/cenox/bemuse-test; # Write location from pwd command.
+    }
+
+}
+```
+
+Save file with `Control+X`, `Y`, `Enter`.
+
+Then, make symlink for config file works
+
+```bash
+$ sudo ln -s /etc/nginx/site-available/bemuse site-enabled/bemuse
+```
+
+Restart nginx,
+
+```bash
+$ sudo systemctl restart nginx
+```
+
+Then connect to the music server with (http://bemuse.ninja/?server=http://localhost).

--- a/docs/music-server.md
+++ b/docs/music-server.md
@@ -9,11 +9,52 @@ sidebar_label: Music Server
 <p>This section is under construction.</p>
 </div>
 
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+
+**Linux is not officially supported for creating Bemuse packages,** as it relies on Apple's AAC codec. You can still host the server files on any Linux machine, though.
+
+</div>
+
 Bemuse comes with a default music server to help new players get started. This default music server contains a selection of songs that I think are really nice. You can also run your own music server and play it in Bemuse. This page describes how you can do it.
 
-This guide is valid for all major operating systems (Windows, Linux, or macOS), and assumes some knowledge about using the command line and web hosting.
+This guide is valid for Windows or macOS, and assumes some knowledge about using the command line and web hosting.
 
 ## Prerequisites
+
+### Debian Linux (Debian, Ubuntu etc.)
+
+- [Node.js](https://nodejs.org/): [Here](https://github.com/nodesource/distributions/blob/master/README.md) is the installation guide from nodejs.
+- [SoX](http://sox.sourceforge.net/): `sudo apt install sox`
+
+If you got error when convert sound, install `libsox-dev` package too.
+
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>
+    <b>Linux is not support M4A conversion because of Apple's AAC codec.</b>
+    <br />
+    If you build bemuse custom server via linux, Apple device can't play the music.
+</p>
+</div>
+
+#### Prerequisite Check
+
+Run these commands inside the Terminal.
+
+**Node.js**: You should see the version number:
+
+```sh-session
+$ node -v
+v11.1.0
+```
+
+**SoX**: You should see the SoX version:
+
+```sh-session
+$ sox --version
+sox:      SoX v14.4.2
+```
 
 ### macOS
 
@@ -163,6 +204,12 @@ Bemuse Tools is a command line application to help you generate files for Bemuse
 PS> npm install -g bemuse-tools
 ```
 
+or if you use yarn:
+
+```bash
+$ yarn global add bemuse-tools
+```
+
 ### Installation Check
 
 Run the following command:
@@ -240,7 +287,16 @@ PS> bemuse-tools pack 'Lapis - SHIKI'
 # Written metadata.json
 ```
 
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>
     If you pack bms files from <b>linux</b>, <code>-> Converting audio to m4a [for iOS and Safari]</code> will get errors because of codec. Converted pack will not play sounds on Apple platform devices.
+</p>
+</div>
+
+### Note
+
+
 Now if you look at your song folder, you should see a new folder called **assets**:
 
     Lapis - SHIKI
@@ -355,3 +411,99 @@ DocumentRoot "C:\Bemuse\myserver"
 Once the file is saved, open your XAMPP Control Pannel and run "Apache".
 
 Then connect to the music server with (http://bemuse.ninja/?server=https://localhost/).
+
+#### Linux or macOS using [Nginx](https://nginx.org/en/)
+
+First, Open terminal and Use `cd` command, move to folder that bemuse custom files contained.
+
+Then, install Nginx
+
+from macOS:
+```bash
+$ brew install nginx
+```
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>
+    Homebrew will install nginx on /usr/local.
+</p>
+</div>
+
+
+from Debian Linux:
+```bash
+$ sudo apt install nginx
+```
+
+Check your current location
+
+```bash
+$ pwd
+# e.g Output: /Users/cenox/Dev/bemuse-test
+```
+
+Memo output location. This will be used when config nginx.
+
+Go to nginx folder.
+
+from macOS:
+```bash
+$ cd /usr/local/nginx/etc
+```
+
+from Debian Linux:
+```bash
+$ cd /etc/nginx
+```
+
+Then, Use `touch` command to make setting files for serve bemuse files.
+
+from macOS:
+```bash
+$ touch servers/bemuse
+```
+
+from Debian Linux:
+```bash
+$ sudo touch sites-available/bemuse
+```
+
+Open bemuse setting file with text editor. This example uses `nano`. Write into setting file.
+
+
+```nginx
+server {
+    listen 80;
+
+    location / {
+        add_header 'Access-Control-Allow-Origin' '*';
+        root /Users/cenox/Dev/bemuse-test; # Write location from pwd command.
+    }
+
+}
+```
+
+Save file with `Control+X`, `Y`, `Enter`.
+
+Reload nginx
+
+from macOS:
+```bash
+$ nginx -s reload
+```
+
+from Debian Linux:
+```bash
+$ sudo systemctl restart nginx
+```
+
+Then connect to the music server with (http://bemuse.ninja/?server=http://localhost).
+
+##### Additional Note.
+
+Linux's nginx runs when OS booted, but macOS isn't.
+You can register service via brew. This makes nginx run when user logged in.
+
+```bash
+$ brew services start nginx
+```


### PR DESCRIPTION
:memo: Bemuse's pack feature is not supported properly by AAC codec on Linux, but still can pack and run. added prerequisites for linux.

:memo: I experienced when install bemuse-tools via yarn can cause `no command` error, added the way how export yarn path.

:memo: Current docs describe xampp-apache based local machine, so added nginx based way for macOS and Linux.