### PR TITLE
:lock: :arrow_up: [bms] lodash-es@4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "homepage": "https://github.com/spacetme/bemuse",
   "devDependencies": {
     "@types/eslint": "^4.16.4",
+    "@types/lodash-es": "^4.17.1",
     "@types/minimatch": "^3.0.3",
     "autoprefixer": "^9.1.5",
     "body-parser": "^1.18.3",

--- a/packages/bms/package.json
+++ b/packages/bms/package.json
@@ -32,10 +32,6 @@
   "homepage": "https://github.com/bemusic/bms-js",
   "devDependencies": {
     "@types/invariant": "^2.2.29",
-    "@types/lodash.assign": "^4.2.4",
-    "@types/lodash.map": "^4.6.13",
-    "@types/lodash.uniq": "^4.5.4",
-    "@types/lodash.values": "^4.3.4",
     "@types/node": "^10.12.12",
     "artstep": "^5555.0.0",
     "bluebird": "^3.5.2",
@@ -53,9 +49,6 @@
     "data-structure": "^1.2.0",
     "iconv-lite": "^0.4.24",
     "invariant": "^2.2.4",
-    "lodash.assign": "^4.2.0",
-    "lodash.map": "^4.6.0",
-    "lodash.uniq": "^4.5.0",
-    "lodash.values": "^4.3.0"
+    "lodash-es": "^4.17.11"
   }
 }

--- a/packages/bms/src/keysounds/index.ts
+++ b/packages/bms/src/keysounds/index.ts
@@ -1,7 +1,7 @@
 // Public: A module that exposes {Keysounds}
 /* module */
 
-import { uniq, values } from '../util/lodash'
+import { uniq, values } from 'lodash-es'
 import { BMSChart } from '../bms/chart'
 
 /**

--- a/packages/bms/src/song-info/index.ts
+++ b/packages/bms/src/song-info/index.ts
@@ -1,5 +1,6 @@
+import { assign } from 'lodash-es'
+
 import { match } from '../util/match'
-import { assign } from '../util/lodash'
 import { BMSChart } from '../bms/chart'
 
 export interface ISongInfoData {

--- a/packages/bms/src/timing/index.ts
+++ b/packages/bms/src/timing/index.ts
@@ -1,5 +1,6 @@
+import { uniq, map } from 'lodash-es'
+
 import { Speedcore } from '../speedcore'
-import { uniq, map } from '../util/lodash'
 import { BMSChart } from '../bms/chart'
 import { SpeedSegment } from '../speedcore/segment'
 

--- a/packages/bms/src/util/lodash.ts
+++ b/packages/bms/src/util/lodash.ts
@@ -1,7 +1,0 @@
-// A subset of lodash that we actually use.
-import uniq from 'lodash.uniq'
-import map from 'lodash.map'
-import values from 'lodash.values'
-import assign from 'lodash.assign'
-
-export { uniq, map, values, assign }

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,38 +840,17 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.1.tgz#fcaa655260285b8061850789f8268c51a4ec8ee1"
   integrity sha512-NVQEMviDWjuen3UW+mU1J6fZ0WhOfG1yRce/2OTcbaz+fgmTw2cahx6N2wh0Yl+a+hg2UZj/oElZmtULWyGIsA==
 
-"@types/lodash.assign@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash.assign/-/lodash.assign-4.2.4.tgz#b9fb0e96450c807ad156812620d0721114f36f42"
-  integrity sha512-vQZhkRxzcp8WfOCN5ss/MJRnReJlyS5bRL7eChoUp38edH04UefqSXwSa873SUwbF87USU4J5iCZi+oc1Jhu2A==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.map@^4.6.13":
-  version "4.6.13"
-  resolved "https://registry.yarnpkg.com/@types/lodash.map/-/lodash.map-4.6.13.tgz#7d776611d4c0345e48cfdfe466d7b291b31d1d13"
-  integrity sha512-kppRBzlpuvQQsr7R2nv/DDDZds8fglRFNAK70WUOkOC18KOcuQ22oQF9Kgy5Z2v/eDNkBm0ltrT6FThSkuWwow==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.uniq@^4.5.4":
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash.uniq/-/lodash.uniq-4.5.4.tgz#8dd571e4a68adddcd1bac810538e68f440e87403"
-  integrity sha512-q0FI7RCY99bUPBR7sJyfefWDa/KSD21pMWM1hi+2O+rJTzY2N4eRs+A6BwLotPNy/JOySfcZJYamZ8Owcs3SkQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.values@^4.3.4":
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash.values/-/lodash.values-4.3.4.tgz#4818903cc23dcd856248eec89b59c9985b006a05"
-  integrity sha512-KuDIbN0zJQvkVzW2dIzVLay0bNeBPi0xMUVfb/QCQ9tJRw/8t2p/MwERbkYPkprJfFbfI3i26aUaw/UAvazYKA==
+"@types/lodash-es@^4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.1.tgz#56745e5411558362aeca31def918f88f725dd29d"
+  integrity sha512-3EDZjphPfdjnsWvY11ufYImFMPyQJwIH1eFYRgWQsjOctce06fmNgVf5sfvXBRiaS1o0X50bAln1lfWs8ZO3BA==
   dependencies:
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.118"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
-  integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
+  version "4.14.120"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.120.tgz#cf265d06f6c7a710db087ed07523ab8c1a24047b"
+  integrity sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==
 
 "@types/minimatch@^3.0.3":
   version "3.0.3"
@@ -8773,7 +8752,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.17.11, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
@@ -8954,7 +8933,7 @@ lodash.keys@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
   integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
 
-lodash.map@^4.4.0, lodash.map@^4.6.0:
+lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
@@ -9061,11 +9040,6 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
-lodash.values@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
-  integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
 
 lodash@^2.4.1, lodash@~2.4.1:
   version "2.4.2"


### PR DESCRIPTION
Upgraded `lodash` in bms package to fix [security issue](https://nvd.nist.gov/vuln/detail/CVE-2018-16487). Used `lodash-es`
package to allow for treeshaking.