### PR TITLE
Suppress freestyle sound when performing a glissando in 3d mode

### DIFF
--- a/src/game/state/player-state.spec.js
+++ b/src/game/state/player-state.spec.js
@@ -314,6 +314,42 @@ describe('PlayerState', function() {
           advance(7.5, { p1_1: 1 })
           assert(state.notifications.sounds[0].note === chart.notes[1])
         })
+        it('suppresses freestyle keysound when column is sandwiched between 2 adjacent notes in 3d mode', function() {
+          setup(
+            `
+              #BPM 60
+              #00111:01
+              #00212:02
+              #00113:02
+            `,
+            { speed: 1, placement: '3d' }
+          )
+          advance(1, { p1_2: 1 })
+          assert.equal(state.notifications.sounds.length, 1)
+          advance(1, { p1_2: 0 })
+
+          advance(4, { p1_2: 1 })
+          assert.equal(state.notifications.sounds.length, 0)
+          advance(4, { p1_2: 0 })
+        })
+        it('does not suppress freestyle keysound outside 3d mode', function() {
+          setup(
+            `
+              #BPM 60
+              #00111:01
+              #00212:02
+              #00113:02
+            `,
+            { speed: 1, placement: 'left' }
+          )
+          advance(1, { p1_2: 1 })
+          assert.equal(state.notifications.sounds.length, 1)
+          advance(1, { p1_2: 0 })
+
+          advance(4, { p1_2: 1 })
+          assert.equal(state.notifications.sounds.length, 1)
+          advance(4, { p1_2: 0 })
+        })
       })
     })
 


### PR DESCRIPTION
### Changelog

When playing in 3D mode (e.g. using a touch screen), performing a fast glissando between 2 notes with one column of gap in-between will no longer emit the sound of the gap. For example, given a note pattern 1-3-5-7, you can swipe your finger from 1~7, and the game will suppress the sounds of column 2-4-6. This improves the playing experience in mobile devices.