### PR TITLE
Support dropping links to zip files

### DIFF
--- a/src/app/song-loader/index.js
+++ b/src/app/song-loader/index.js
@@ -4,6 +4,10 @@ import Worker from './song-loader.worker.js'
 
 export function loadSongFromResources(resources, options = {}) {
   var onMessage = options.onMessage || (() => {})
+  console.log(resources)
+  if (resources.setLoggingFunction) {
+    resources.setLoggingFunction(onMessage)
+  }
   return resources.fileList
     .then(fileList => {
       console.log(fileList)

--- a/src/resources/resource-logging.ts
+++ b/src/resources/resource-logging.ts
@@ -1,0 +1,18 @@
+import { LoggingFunction } from './types'
+
+export default class ResourceLogging {
+  private buffer: string[] | null = []
+  private loggingFunction: LoggingFunction = text => {
+    if (this.buffer) this.buffer.push(text)
+  }
+  public log: LoggingFunction = text => {
+    this.loggingFunction(text)
+  }
+  setLoggingFunction = (fn: LoggingFunction) => {
+    this.loggingFunction = fn
+    if (this.buffer) {
+      this.buffer.forEach(text => fn(text))
+      this.buffer = null
+    }
+  }
+}

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -2,6 +2,7 @@ import Progress from 'bemuse/progress'
 
 export interface IResources {
   file(name: string): PromiseLike<IResource>
+  setLoggingFunction?: (logFn: LoggingFunction) => void
 }
 
 export interface IResource {
@@ -14,3 +15,4 @@ export interface IResource {
 }
 
 export type FileEntry = { name: string; file: File }
+export type LoggingFunction = (text: string) => void


### PR DESCRIPTION
### Changelog

**You can now drop a link to a BMS archive (.zip, .rar) from another web page into the “Custom BMS” panel.** When you do it, Bemuse will attempt to download and extract the file. Note that for this to work, the web server that serves the file must set up [cross-origin resource sharing](https://enable-cors.org/) to allow Bemuse to download it. Both Dropbox and IPFS gateways has this set up already.

Dropbox URL normalization code is based on [@Nekokan]’s [Dropbox Replacer](http://nekokan.dyndns.info/tool/DropboxReplacer/), thanks!