### PR TITLE
Disable breaks when markdown is safe to fix CHANGELOG linebreaking

### DIFF
--- a/src/ui/Markdown.jsx
+++ b/src/ui/Markdown.jsx
@@ -12,7 +12,6 @@ const markdown = new Markdown({
 const safeMarkdown = new Markdown({
   html: true,
   linkify: true,
-  breaks: true,
   typographer: true,
 })
 


### PR DESCRIPTION
### Changelog

Fixed a CHANGELOG formatting issue where changelog text is broken into multiple lines when viewed in Bemuse.