### PR TITLE
Updates usage of `co` to async function in pre-deploy.js

### DIFF
--- a/tasks/pre-deploy.js
+++ b/tasks/pre-deploy.js
@@ -1,22 +1,16 @@
 import gulp from 'gulp'
 import fs from 'fs'
 import path from '../config/path'
-import co from 'co'
 import Promise from 'bluebird'
 
 const readFile = Promise.promisify(fs.readFile, fs)
 
-gulp.task(
-  'pre-deploy',
-  // TODO [#638]: Convert the `co.wrap()` call in tasks/pre-deploy.js to async function
-  // See issue #575 for more details.
-  co.wrap(function*() {
-    let data = yield readFile(path('dist', 'index.html'), 'utf-8')
-    check('New Relic inlined', () => /NREUM/.test(data))
-    check('Boot script inlined', () => /webpackJsonp/.test(data))
-    check('Google Analytics inlined', () => /GoogleAnalyticsObject/.test(data))
-  })
-)
+gulp.task('pre-deploy', async function() {
+  const data = await readFile(path('dist', 'index.html'), 'utf-8')
+  check('New Relic inlined', () => /NREUM/.test(data))
+  check('Boot script inlined', () => /webpackJsonp/.test(data))
+  check('Google Analytics inlined', () => /GoogleAnalyticsObject/.test(data))
+})
 
 function check(title, condition) {
   if (condition()) {


### PR DESCRIPTION
fixes #638 

### Changelog

Migrate part of the code from `co` to `async function`s