### PR TITLE
Some input handling changes

### DIFF
--- a/src/app/entities/Options.js
+++ b/src/app/entities/Options.js
@@ -137,6 +137,18 @@ export const changeAudioInputLatency = latency =>
     'system.offset.audio-input': `${latency}`,
   })
 
+// Gamepad Continuous Axis
+export const isContinuousAxisEnabled = state =>
+  toggleOptionEnabled(state['gamepad.continuous'])
+export const toggleContinuousAxis = u({
+  'gamepad.continuous': toggleOption,
+})
+
+// Gamepad Sensitivity
+export const sensitivity = state => state['gamepad.sensitivity']
+export const changeSensitivity = sensitivity =>
+  u({ 'gamepad.sensitivity': sensitivity })
+
 // Latest version
 export const lastSeenVersion = state => state['system.last-seen-version']
 export const updateLastSeenVersion = newVersion =>

--- a/src/app/game-launcher.ts
+++ b/src/app/game-launcher.ts
@@ -99,6 +99,8 @@ export async function launch({
         gauge: Options.getGauge(options),
         input: {
           keyboard: keyboardMapping as any,
+          continuous: Options.isContinuousAxisEnabled(options),
+          sensitivity: Options.sensitivity(options),
         },
       },
     ],

--- a/src/app/options.js
+++ b/src/app/options.js
@@ -41,6 +41,10 @@ export const DEFAULTS = {
   // Gauge type (off, hope)
   'player.P1.gauge': 'off',
 
+  // Gamepad settings
+  'gamepad.continuous': '0',
+  'gamepad.sensitivity': '4',
+
   // Offsets
   'system.offset.audio-input': '0',
   'system.offset.audio-visual': '0',

--- a/src/app/ui/OptionsInput.jsx
+++ b/src/app/ui/OptionsInput.jsx
@@ -7,13 +7,16 @@ import c from 'classnames'
 import { compose, withHandlers, withState } from 'recompose'
 import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
-import { getName, key川 } from 'bemuse/omni-input'
+import OmniInput, { getName, key川 } from 'bemuse/omni-input'
 
 import * as Options from '../entities/Options'
 import * as OptionsIO from '../io/OptionsIO'
 import OptionsInputKeys from './OptionsInputKeys'
 import OptionsInputScratch from './OptionsInputScratch'
 import connectIO from '../../impure-react/connectIO'
+import OptionsCheckbox from './OptionsCheckbox'
+import OptionsInputField from './OptionsInputField'
+import OptionsButton from './OptionsButton'
 
 const selectKeyboardMapping = createSelector(
   state => state.options,
@@ -30,11 +33,14 @@ const enhance = compose(
     scratch: Options.scratchPosition(state.options),
     texts: selectKeyboardMappingTexts(state),
     mode: Options.playMode(state.options),
+    isContinuous: Options.isContinuousAxisEnabled(state.options),
+    sensitivity: Options.sensitivity(state.options),
   })),
   withState('editing', 'setEditing', null),
   connectIO({
     onSetKeyCode: ({ mode, editing }) => keyCode =>
       OptionsIO.updateOptions(Options.changeKeyMapping(mode, editing, keyCode)),
+    onUpdateOptions: () => updater => OptionsIO.updateOptions(updater),
   }),
   withHandlers({
     onEdit: ({ editing, setEditing }) => key => {
@@ -60,6 +66,9 @@ class OptionsInput extends React.Component {
     editing: PropTypes.string,
     onEdit: PropTypes.func,
     onKey: PropTypes.func,
+    isContinuous: PropTypes.bool,
+    sensitivity: PropTypes.number,
+    onUpdateOptions: PropTypes.func,
   }
   render() {
     const className = c('OptionsInput', {
@@ -67,37 +76,75 @@ class OptionsInput extends React.Component {
     })
     return (
       <div className={className}>
-        {this.props.scratch !== 'off' ? (
-          <div className='OptionsInputのzone is-scratch'>
+        <div className='OptionsInputのbinding'>
+          {this.props.scratch !== 'off' ? (
+            <div className='OptionsInputのzone is-scratch'>
+              <div className='OptionsInputのcontrol'>
+                <OptionsInputScratch
+                  text={[this.props.texts['SC'], this.props.texts['SC2']]}
+                  isEditing={
+                    this.props.editing === 'SC' || this.props.editing === 'SC2'
+                  }
+                  editIndex={
+                    this.props.editing === 'SC'
+                      ? 0
+                      : this.props.editing === 'SC2'
+                      ? 1
+                      : -1
+                  }
+                  onEdit={this.handleEdit}
+                />
+              </div>
+              <div className='OptionsInputのtitle'>Scratch</div>
+            </div>
+          ) : null}
+          <div className='OptionsInputのzone'>
             <div className='OptionsInputのcontrol'>
-              <OptionsInputScratch
-                text={[this.props.texts['SC'], this.props.texts['SC2']]}
-                isEditing={
-                  this.props.editing === 'SC' || this.props.editing === 'SC2'
-                }
-                editIndex={
-                  this.props.editing === 'SC'
-                    ? 0
-                    : this.props.editing === 'SC2'
-                    ? 1
-                    : -1
-                }
+              <OptionsInputKeys
+                keyboardMode={this.props.scratch === 'off'}
+                texts={this.props.texts}
+                editing={this.props.editing}
                 onEdit={this.handleEdit}
               />
             </div>
-            <div className='OptionsInputのtitle'>Scratch</div>
+            <div className='OptionsInputのtitle'>Keys</div>
           </div>
-        ) : null}
-        <div className='OptionsInputのzone'>
-          <div className='OptionsInputのcontrol'>
-            <OptionsInputKeys
-              keyboardMode={this.props.scratch === 'off'}
-              texts={this.props.texts}
-              editing={this.props.editing}
-              onEdit={this.handleEdit}
+        </div>
+        <div className='OptionsInputのgamepad'>
+          <div className='OptionsInputのgroup'>
+            <label>Continuous Axis</label>
+            <OptionsCheckbox
+              checked={this.props.isContinuous}
+              onToggle={() => {
+                this.props.onUpdateOptions(Options.toggleContinuousAxis)
+                this._input.setGamepadContinuousAxisEnabled(
+                  !this.props.isContinuous
+                )
+              }}
             />
           </div>
-          <div className='OptionsInputのtitle'>Keys</div>
+          <div className='OptionsInputのgroup'>
+            <label>Sensitivity</label>
+            <div className='OptionsInputのsensitivity'>
+              <span className='OptionsInputのminus'>
+                <OptionsButton onClick={this.handleMinusButtonClick}>
+                  -
+                </OptionsButton>
+              </span>
+              <OptionsInputField
+                parse={str => parseInt(str, 10) - 1}
+                stringify={value => String(parseInt(value, 10) + 1)}
+                validator={/^[0-9]+$/}
+                value={this.props.sensitivity}
+                onChange={this.handleSensitivityChange}
+              />
+              <span className='OptionsInputのplus'>
+                <OptionsButton onClick={this.handlePlusButtonClick}>
+                  +
+                </OptionsButton>
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     )
@@ -108,7 +155,10 @@ class OptionsInput extends React.Component {
   componentDidMount() {
     // XXX: debounce is needed because some gamepad inputs trigger multiple
     // buttons
-    this._dispose = key川()
+    this._input = new OmniInput(window, {
+      continuous: this.props.isContinuous,
+    })
+    this._dispose = key川(this._input)
       .debounceImmediate(16)
       .doLog('a')
       .onValue(this.handleKey)
@@ -116,6 +166,7 @@ class OptionsInput extends React.Component {
   }
   componentWillUnmount() {
     if (this._dispose) this._dispose()
+    if (this._input) this._input.dispose()
     window.removeEventListener('keydown', this.handleKeyboardEvent, true)
   }
   handleKey = key => {
@@ -127,6 +178,19 @@ class OptionsInput extends React.Component {
     if (this.props.editing) {
       e.preventDefault()
     }
+  }
+  handleSensitivityChange = sensitivity => {
+    if (sensitivity < 0) sensitivity = 0
+    else if (sensitivity >= 10) sensitivity = 9
+    this._input.setGamepadSensitivity(sensitivity)
+    this.props.onUpdateOptions(Options.changeSensitivity(sensitivity))
+  }
+  handleMinusButtonClick = () => {
+    this.handleSensitivityChange(parseInt(this.props.sensitivity, 10) - 1)
+  }
+
+  handlePlusButtonClick = () => {
+    this.handleSensitivityChange(parseInt(this.props.sensitivity, 10) + 1)
   }
 }
 

--- a/src/app/ui/OptionsInput.jsx
+++ b/src/app/ui/OptionsInput.jsx
@@ -71,12 +71,12 @@ class OptionsInput extends React.Component {
     onUpdateOptions: PropTypes.func,
   }
   render() {
-    const className = c('OptionsInput', {
+    const className = c('OptionsInputのbinding', {
       'is-reverse': this.props.scratch === 'right',
     })
     return (
-      <div className={className}>
-        <div className='OptionsInputのbinding'>
+      <div className='OptionsInput'>
+        <div className={className}>
           {this.props.scratch !== 'off' ? (
             <div className='OptionsInputのzone is-scratch'>
               <div className='OptionsInputのcontrol'>

--- a/src/app/ui/OptionsInput.scss
+++ b/src/app/ui/OptionsInput.scss
@@ -2,10 +2,15 @@
 
 .OptionsInput {
   display: flex;
-  align-items: stretch;
-  padding: 2em;
-  &.is-reverse {
-    flex-direction: row-reverse;
+  flex-direction: column;
+
+  &のbinding {
+    display: flex;
+    align-items: stretch;
+    padding: 2em;
+    &.is-reverse {
+      flex-direction: row-reverse;
+    }
   }
   &のzone {
     display: flex;
@@ -20,5 +25,50 @@
     text-align: center;
     padding-top: 1ex;
     color: #8b8685;
+  }
+
+  &のgamepad {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    padding: 10px;
+  }
+
+  &のgroup {
+    display: flex;
+    align-items: baseline;
+  }
+
+  &のgroup > label {
+    font-weight: bold;
+    color: #8b8685;
+    margin-right: 1em;
+  }
+
+  &のsensitivity {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-right: 0.5em;
+  }
+
+  &のsensitivity > .OptionsInputField {
+    text-align: center;
+    width: 1em;
+    border-radius: 0;
+    margin-left: -1px;
+  }
+
+  &のminus .OptionsButton {
+    width: 2em;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &のplus .OptionsButton {
+    width: 2em;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    margin-left: -1px;
   }
 }

--- a/src/game/input/dual-input.ts
+++ b/src/game/input/dual-input.ts
@@ -1,0 +1,34 @@
+export class DualInput {
+  /*
+    A helper class for mapping two boolean inputs to a single integer output.
+    This provide robust and responsive output when quickly firing two inputs alternatively.
+  */
+
+  // input states -1: up, 0: off, 1: down, 2: hold
+  private input = [0, 0]
+  private last = 0
+  private output = 0
+
+  public combine(...input: [boolean, boolean]) {
+    for (let i = 0; i < 2; ++i) {
+      if (input[i] && this.input[i] <= 0) {
+        this.input[i] = 1
+        this.last = i
+      } else if (!input[i] && this.input[i] > 0) {
+        this.input[i] = -1
+      } else if (this.input[i] % 2 !== 0) {
+        this.input[i] += 1
+      }
+    }
+
+    if (this.input[0] === 1 || this.input[1] === 1) {
+      this.output = this.last === 0 ? 1 : -1
+    }
+
+    if (this.input[this.last] <= 0) {
+      this.output = 0
+    }
+
+    return this.output
+  }
+}

--- a/src/game/input/omni-input-plugin.js
+++ b/src/game/input/omni-input-plugin.js
@@ -10,6 +10,11 @@ function OmniInputPlugin(game) {
   let kbm = game.players[0].options.input.keyboard
   const scratch = new DualInput()
 
+  // Don't use Btn8 or Btn9 if they are binded
+  // TODO: make start and select button bindable
+  const isBtn8Free = Object.values(kbm).indexOf('gamepad.0.button.8') < 0
+  const isBtn9Free = Object.values(kbm).indexOf('gamepad.0.button.9') < 0
+
   return {
     name: 'GameKBPlugin',
     get() {
@@ -29,8 +34,8 @@ function OmniInputPlugin(game) {
         ),
         p1_speedup: data[38],
         p1_speeddown: data[40],
-        start: data[13] || data['gamepad.0.button.9'],
-        select: data[18] || data['gamepad.0.button.8'],
+        start: data[13] || (isBtn9Free && data['gamepad.0.button.9']),
+        select: data[18] || (isBtn8Free && data['gamepad.0.button.8']),
       }
       if (result['start'] || result['select']) {
         if (

--- a/src/game/input/omni-input-plugin.js
+++ b/src/game/input/omni-input-plugin.js
@@ -1,12 +1,16 @@
 import { OmniInput } from 'bemuse/omni-input'
+import { DualInput } from './dual-input'
 
 function OmniInputPlugin(game) {
   const input = new OmniInput(window, { exclusive: true })
   let kbm = game.players[0].options.input.keyboard
+  const scratch = new DualInput()
+
   return {
     name: 'GameKBPlugin',
     get() {
       const data = input.update()
+
       const result = {
         p1_1: data[kbm['1'] || '83'],
         p1_2: data[kbm['2'] || '68'],
@@ -15,7 +19,10 @@ function OmniInputPlugin(game) {
         p1_5: data[kbm['5'] || '74'],
         p1_6: data[kbm['6'] || '75'],
         p1_7: data[kbm['7'] || '76'],
-        p1_SC: data[kbm['SC'] || '65'] || -data[kbm['SC2'] || '16'],
+        p1_SC: scratch.combine(
+          data[kbm['SC'] || '65'],
+          data[kbm['SC2'] || '16']
+        ),
         p1_speedup: data[38],
         p1_speeddown: data[40],
         start: data[13] || data['gamepad.0.button.9'],

--- a/src/game/input/omni-input-plugin.js
+++ b/src/game/input/omni-input-plugin.js
@@ -2,7 +2,11 @@ import { OmniInput } from 'bemuse/omni-input'
 import { DualInput } from './dual-input'
 
 function OmniInputPlugin(game) {
-  const input = new OmniInput(window, { exclusive: true, continous: true })
+  const input = new OmniInput(window, {
+    exclusive: true,
+    continuous: game.players[0].options.input.continuous,
+    sensitivity: game.players[0].options.input.sensitivity,
+  })
   let kbm = game.players[0].options.input.keyboard
   const scratch = new DualInput()
 

--- a/src/game/input/omni-input-plugin.js
+++ b/src/game/input/omni-input-plugin.js
@@ -2,7 +2,7 @@ import { OmniInput } from 'bemuse/omni-input'
 import { DualInput } from './dual-input'
 
 function OmniInputPlugin(game) {
-  const input = new OmniInput(window, { exclusive: true })
+  const input = new OmniInput(window, { exclusive: true, continous: true })
   let kbm = game.players[0].options.input.keyboard
   const scratch = new DualInput()
 

--- a/src/game/player.ts
+++ b/src/game/player.ts
@@ -20,6 +20,8 @@ export type PlayerOptionsGauge = 'off' | 'hope'
 
 type PlayerOptionsInputMapping = {
   keyboard: { [control in PlayerControlKeys]: string }
+  continuous: boolean
+  sensitivity: number
 }
 
 type PlayerOptionsInternal = {

--- a/src/omni-input/axis-logic.ts
+++ b/src/omni-input/axis-logic.ts
@@ -1,0 +1,55 @@
+export class AxisLogic {
+  private threshold = 5
+  private stop = 1
+  private charge = 0
+  private previous: false | number = false
+  private active = false
+  private positive = false
+
+  public update(axis: number) {
+    if (this.previous === false) {
+      this.previous = axis
+      return 0
+    }
+
+    if (this.previous !== axis) {
+      let delta = axis - this.previous
+      if (delta > 1) {
+        delta -= 2 + 0.005
+      } else if (delta < -1) {
+        delta += 2 + 0.005
+      }
+
+      let immediateOutput = delta > 0
+      const ticks = Math.ceil(Math.abs(delta) / 0.01)
+
+      if (this.active && this.positive !== immediateOutput) {
+        this.positive = immediateOutput
+        this.active = false
+        this.charge = 0
+      } else if (!this.active) {
+        if (this.charge === 0 || this.stop <= this.threshold) {
+          this.charge += ticks
+        }
+
+        if (this.charge >= 2) {
+          this.active = true
+          this.positive = immediateOutput
+        }
+      }
+
+      this.stop = 0
+      this.previous = axis
+    }
+
+    if (this.stop > this.threshold * 2) {
+      this.active = false
+      this.charge = 0
+      this.stop = 0
+    }
+
+    this.stop += 1
+
+    return this.active ? (this.positive ? 1 : -1) : 0
+  }
+}

--- a/src/omni-input/axis-logic.ts
+++ b/src/omni-input/axis-logic.ts
@@ -1,12 +1,11 @@
 export class AxisLogic {
-  private threshold = 5
   private stop = 1
   private charge = 0
   private previous: false | number = false
   private active = false
   private positive = false
 
-  public update(axis: number) {
+  public update(axis: number, threshold: number = 3) {
     if (this.previous === false) {
       this.previous = axis
       return 0
@@ -21,15 +20,14 @@ export class AxisLogic {
       }
 
       let immediateOutput = delta > 0
-      const ticks = Math.ceil(Math.abs(delta) / 0.01)
 
       if (this.active && this.positive !== immediateOutput) {
         this.positive = immediateOutput
         this.active = false
         this.charge = 0
       } else if (!this.active) {
-        if (this.charge === 0 || this.stop <= this.threshold) {
-          this.charge += ticks
+        if (this.charge === 0 || this.stop <= threshold) {
+          this.charge += Math.ceil(Math.abs(delta) / 0.01)
         }
 
         if (this.charge >= 2) {
@@ -42,7 +40,7 @@ export class AxisLogic {
       this.previous = axis
     }
 
-    if (this.stop > this.threshold * 2) {
+    if (this.stop > threshold * 2) {
       this.active = false
       this.charge = 0
       this.stop = 0

--- a/src/omni-input/index.js
+++ b/src/omni-input/index.js
@@ -31,9 +31,8 @@ export class OmniInput {
     const midi川 = (options.getMidi川 || getMidi川)()
     this._window = win
     this._exclusive = !!options.exclusive
-
-    this._deadzone = options.deadzone || 0.02
-    this._continousAxis = !!options.continous
+    this._continuousAxis = !!options.continuous
+    this.setGamepadSensitivity(options.sensitivity || 3)
 
     this._disposables = [
       listen(win, 'keydown', e => this._handleKeyDown(e)),
@@ -110,7 +109,7 @@ export class OmniInput {
       const axisName = `${prefix}.axis.${i}`
       let axis = gamepad.axes[i]
 
-      if (this._continousAxis) {
+      if (this._continuousAxis) {
         if (this._axis[axisName] == null) {
           this._axis[axisName] = new AxisLogic()
         }
@@ -125,6 +124,18 @@ export class OmniInput {
     this._updateGamepads()
     return this._status
   }
+
+  setGamepadSensitivity(sensitivity) {
+    this._sensitivity = sensitivity
+    this._deadzone = (9 - this._sensitivity) * 0.05
+    if (this._deadzone < 0.01) this._deadzone = 0.01
+    this._analogThreshold = 18 - this._sensitivity * 2
+  }
+
+  setGamepadContinuousAxisEnabled(enabled) {
+    this._continuousAxis = enabled
+  }
+
   dispose() {
     for (let dispose of this._disposables) {
       dispose()
@@ -134,10 +145,7 @@ export class OmniInput {
 
 // Public: Returns a Bacon EventStream of keys pressed.
 //
-export function key川(
-  input = new OmniInput(window, { continous: true }),
-  win = window
-) {
+export function key川(input = new OmniInput(), win = window) {
   return _key川ForUpdate川(
     Bacon.fromBinder(sink => {
       const handle = win.setInterval(() => {

--- a/src/omni-input/index.js
+++ b/src/omni-input/index.js
@@ -2,6 +2,7 @@ import keycode from 'keycode'
 import _ from 'lodash'
 import Bacon from 'baconjs'
 import getMidi川 from './midi'
+import { AxisLogic } from './axis-logic'
 
 // Public: OmniInput is a poll-based class that handles the key-pressed state of
 // multiple inputs.
@@ -30,12 +31,17 @@ export class OmniInput {
     const midi川 = (options.getMidi川 || getMidi川)()
     this._window = win
     this._exclusive = !!options.exclusive
+
+    this._deadzone = options.deadzone || 0.02
+    this._continousAxis = !!options.continous
+
     this._disposables = [
       listen(win, 'keydown', e => this._handleKeyDown(e)),
       listen(win, 'keyup', e => this._handleKeyUp(e)),
       midi川.onValue(e => this._handleMIDIMessage(e)),
     ]
     this._status = {}
+    this._axis = {}
   }
   _handleKeyDown(e) {
     this._status[`${e.which}`] = true
@@ -101,9 +107,18 @@ export class OmniInput {
       this._status[`${prefix}.button.${i}`] = button && button.value >= 0.5
     }
     for (let i = 0; i < gamepad.axes.length; i++) {
-      const axis = gamepad.axes[i]
-      this._status[`${prefix}.axis.${i}.positive`] = axis >= 0.01
-      this._status[`${prefix}.axis.${i}.negative`] = axis <= -0.01
+      const axisName = `${prefix}.axis.${i}`
+      let axis = gamepad.axes[i]
+
+      if (this._continousAxis) {
+        if (this._axis[axisName] == null) {
+          this._axis[axisName] = new AxisLogic()
+        }
+        axis = this._axis[axisName].update(axis)
+      }
+
+      this._status[`${axisName}.positive`] = axis >= this._deadzone
+      this._status[`${axisName}.negative`] = axis <= -this._deadzone
     }
   }
   update() {
@@ -119,7 +134,10 @@ export class OmniInput {
 
 // Public: Returns a Bacon EventStream of keys pressed.
 //
-export function key川(input = new OmniInput(), win = window) {
+export function key川(
+  input = new OmniInput(window, { continous: true }),
+  win = window
+) {
   return _key川ForUpdate川(
     Bacon.fromBinder(sink => {
       const handle = win.setInterval(() => {


### PR DESCRIPTION
1. Created a dual input helper for responsive scratching when alternating two scratch keys.
2. Added an alternative turntable input style, currently dubbed "Continuous Axis". Fixes #450 
3. Added adjustable turntable "sensitivity"
  - For positive/negative input mode, the higher the sensitivity, the smaller the deadzone is.
  - For continuous input mode, the higher the sensitivity, the quicker the turntable would stop.
4. Disable gamepad 0's Btn8 and Btn9 if they are binded. (To avoid changing speed on a single button on some controllers).

Options:
![image](https://user-images.githubusercontent.com/3797859/76360615-42899f80-6315-11ea-8b84-1396153623ba.png)

Let me know if any UI changes or terminology changes is needed.

### Changelog

**Added support to gamepad controllers that sets the axis value in a continuous fashion.** Some controllers call this INFINITAS mode. This also adds a new “turntable sensitivity” settings. In addition, if the buttons 8 or 9 are mapped, they will no longer function as a “start” and “select” buttons (to avoid changing speed on a single button on some controllers).