### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const siteConfig = {
+  algolia: {
+    apiKey: 'a113c79cadd1ce125abb6011106af056',
+    indexName: 'bemuse',
+  },
   title: 'Bemuse' /* title for your website */,
   tagline: 'online, web-based rhythm game',
   url: 'https://bemuse.ninja' /* your website url */,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.

### Changelog

**Our documentation site is now searchable.** Courtesy of Algolia’s [DocSearch](https://docsearch.algolia.com/) program.