### PR TITLE
Add link to Community FAQ from various places

### DIFF
--- a/bemuse/src/app/ui/TitleScene.jsx
+++ b/bemuse/src/app/ui/TitleScene.jsx
@@ -59,6 +59,11 @@ class TitleScene extends React.Component {
       Toolbar.item('About', {
         onClick: this.showAbout,
       }),
+      Toolbar.item('Community FAQ', {
+        href: 'https://faq.bemuse.ninja',
+        tip: 'New',
+        tipFeatureKey: 'faq',
+      }),
       Toolbar.item('Docs', {
         href: '/project/',
       }),
@@ -70,18 +75,13 @@ class TitleScene extends React.Component {
       Toolbar.spacer(),
       Toolbar.item('Discord', {
         href: 'https://discord.gg/aB6ucmx',
-        tip: 'Join our Discord server',
+        tip: 'Join our community',
         tipFeatureKey: 'discord',
-      }),
-      Toolbar.item('Facebook', {
-        href: 'https://www.facebook.com/bemusegame',
       }),
       Toolbar.item('Twitter', {
         href: 'https://twitter.com/bemusegame',
-        tip: 'Follow us :)',
-        tipFeatureKey: 'twitter',
       }),
-      Toolbar.item('Fork me on GitHub', {
+      Toolbar.item('GitHub', {
         href: 'https://github.com/bemusic/bemuse',
       }),
     ]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,35 +3,19 @@ id: faq
 title: FAQ
 ---
 
+The FAQ contents has been moved to a Community FAQ site at
+<https://faq.bemuse.ninja/>
+
+<div style="height: 100vh"></div>
+
 ## How do I adjust the speed?
 
-To set the speed in-game, use the Up and Down buttons on your keyboard. This
-adjusts the speed by 0.5x. If you hold down Alt, the speed is adjusted by 0.1x
-instead.
+[_This section has been moved._](https://faq.bemuse.ninja/#723788b29a1e44a4a3e14e6b985dfe46)
 
 ## There is a huge audio latency\! Can it be fixed?
 
-As a web-based game, it does not have low-level access to the audio driver.
-There are many factors that affect the audio latency in this game (and web-based
-audio applications in general):
-
-- The browser's implementation of the Web Audio technology
-- Your sound card driver and settings on your operating system
-
-Bemuse has a mechanism for delay compensation. Simply open the options screen
-and enter your system’s audio+input latency. You can click on the “Calibrate”
-button to find out your system’s audio+input latency.
-
-From my experience, Safari has the lowest latency so far.
+[_This section has been moved._](https://faq.bemuse.ninja/#be15ff200f244da9bc7ba0563006d1f4)
 
 ## The game runs poorly in my browser!
 
-If you're getting low FPS while playing Bemuse, please make sure you have
-hardware acceleration turned on to make the game run smoothly.
-
-Here's how to turn it on in different browsers:
-
-- **Chrome (and Microsoft Edge):** Settings > Show advanced settings > System >
-  Use hardware acceleration when available
-- **Firefox:** Options > Performance > Use recommended performance settings
-- **Safari:** Hardware acceleration is enabled by default.
+[_This section has been moved._](https://faq.bemuse.ninja/#cfbaf468d0f64f9eaa86543e77c8cb46)

--- a/docs/scoring-and-judgment.md
+++ b/docs/scoring-and-judgment.md
@@ -9,12 +9,12 @@ The scoring system and judgment system in Bemuse focuses on both accuracy and co
 
 When hitting the note, the accuracy of your button press will be judged according to this table:
 
-| Judgment   | Normal | Level5 | Level4 | Level3 | Beginner |
-| ---------- | -----: | -----: | -----: | -----: | -------: |
-| Meticulous |   20ms |   21ms |   22ms |   23ms |     24ms |
-| Precise    |   50ms |   60ms |   70ms |   80ms |    100ms |
-| Good       |  100ms |  120ms |  140ms |  160ms |    180ms |
-| Offbeat    |  200ms |  200ms |  200ms |  200ms |    200ms |
+| Judgment   | Normal | Level5 | Level4 | Level3 | Beginner | Score |
+| ---------- | -----: | -----: | -----: | -----: | -------: | -----:|
+| Meticulous |   20ms |   21ms |   22ms |   23ms |     24ms |  100% |
+| Precise    |   50ms |   60ms |   70ms |   80ms |    100ms |   80% |
+| Good       |  100ms |  120ms |  140ms |  160ms |    180ms |   50% |
+| Offbeat    |  200ms |  200ms |  200ms |  200ms |    200ms |    0% |
 
 The different timegates are designed to make the game easier for beginners, with a gradual increase in difficulty the harder the song gets. They are divided as follows:
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -43,8 +43,9 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>Community</h5>
+            <a href='https://discord.gg/aB6ucmx'>Discord Community</a>
+            <a href='https://faq.bemuse.ninja'>Community FAQ</a>
             <a href={this.props.config.repoUrl}>GitHub Project</a>
-            <a href='https://discord.gg/aB6ucmx'>Chat on Discord</a>
           </div>
           <div>
             <h5>Social</h5>

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -55,6 +55,7 @@
     "links": {
       "Play": "Play",
       "Docs": "Docs",
+      "Community FAQ": "Community FAQ",
       "Contribute": "Contribute",
       "Discord": "Discord",
       "GitHub": "GitHub"

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -14,6 +14,7 @@ const siteConfig = {
   headerLinks: [
     { href: 'https://bemuse.ninja', label: 'Play' },
     { doc: 'user-guide', label: 'Docs' },
+    { href: 'https://faq.bemuse.ninja', label: 'Community FAQ' },
     { page: 'contribute', label: 'Contribute' },
     { href: 'https://discord.gg/aB6ucmx', label: 'Discord' },
     { href: 'https://github.com/bemusic/bemuse', label: 'GitHub' },


### PR DESCRIPTION
### Changelog

**Added a [Community FAQ page](https://faq.bemuse.ninja/).** This page is maintained by the community on [Bemuse Discord server](https://discord.gg/aB6ucmx) and is aimed to answer common questions. If you don’t find your question answered, feel free to ask your questions in `#general`!