### PR TITLE
Add a generic error handling scene

### DIFF
--- a/bemuse/src/app/ui/GenericErrorScene.scss
+++ b/bemuse/src/app/ui/GenericErrorScene.scss
@@ -1,0 +1,23 @@
+@import '~bemuse/ui/common';
+
+.GenericErrorScene {
+  @include scene-background(url(~bemuse/ui/images/bg/c.jpg));
+
+  &のwrapper {
+    padding: 1em;
+    width: 32em;
+    max-width: 90vw;
+    box-sizing: border-box;
+  }
+  &のstack {
+    @include input;
+    color: #faa;
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    height: 16em;
+    margin: 0 0 0.5em;
+    font-family: Menlo, Consolas, monospace;
+    font-size: 0.72em;
+  }
+}

--- a/bemuse/src/app/ui/GenericErrorScene.tsx
+++ b/bemuse/src/app/ui/GenericErrorScene.tsx
@@ -1,0 +1,66 @@
+import './GenericErrorScene.scss'
+
+import React from 'react'
+import OptionsButton from './OptionsButton'
+import ModalPopup from 'bemuse/ui/ModalPopup'
+import Panel from 'bemuse/ui/Panel'
+import Scene from 'bemuse/ui/Scene'
+
+import * as Analytics from '../analytics'
+
+export default function GenericErrorScene(props: {
+  preamble: string
+  error: Error
+  onContinue: () => void
+}) {
+  const { preamble, error, onContinue } = props
+  const details = React.useMemo(
+    () => {
+      return [
+        preamble,
+        '',
+        '[Error]',
+        String(error),
+        '',
+        '[User agent]',
+        navigator.userAgent,
+        '',
+        '[Stack trace]',
+        String((error && error.stack) || error),
+      ].join('\n')
+    },
+    [error, preamble]
+  )
+  return (
+    <Scene className='GenericErrorScene'>
+      <ModalPopup>
+        <Panel title='Error'>
+          <div className='GenericErrorSceneのwrapper'>
+            <textarea
+              className='GenericErrorSceneのstack'
+              value={details}
+              readOnly
+            />
+
+            <div style={{ textAlign: 'right' }}>
+              <OptionsButton
+                onClick={() => {
+                  Analytics.send('error', 'continue', String(error))
+                  onContinue()
+                }}
+              >
+                Continue
+              </OptionsButton>
+            </div>
+          </div>
+        </Panel>
+      </ModalPopup>
+    </Scene>
+  )
+}
+
+GenericErrorScene.getScene = (
+  props: React.ComponentPropsWithoutRef<typeof GenericErrorScene>
+) => {
+  return <GenericErrorScene {...props} />
+}

--- a/bemuse/src/devtools/playgrounds/error.jsx
+++ b/bemuse/src/devtools/playgrounds/error.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import MAIN from 'bemuse/utils/main-element'
+import GenericErrorScene from 'bemuse/app/ui/GenericErrorScene'
+import ReactDOM from 'react-dom'
+
+const ErrorScene = () => (
+  <div>
+    <GenericErrorScene error={new Error('yabai')} preamble='Test error.' />
+  </div>
+)
+
+export function main() {
+  ReactDOM.render(<ErrorScene />, MAIN)
+}


### PR DESCRIPTION
Problems: The game softlocks when some files cannot be loaded

Solution: create a generic scene that can be displayed whenever an error happens while playing the game

### Changelog

You can go back to Music Selection Screen when the game fails to load a song. (Previously, the game would softlock.)