### PR TITLE
Increase after-finish delay

### DIFF
--- a/bemuse/src/game/state/player-state.ts
+++ b/bemuse/src/game/state/player-state.ts
@@ -96,7 +96,7 @@ export class PlayerState {
     this._updateInputColumnMap()
     this._judgeNotes()
     this._updateSpeed()
-    if (gameTime > this._duration + 1) this.finished = true
+    if (gameTime > this._duration + 3) this.finished = true
   }
 
   getNoteStatus(note: GameNote): NoteStatus {


### PR DESCRIPTION
### Changelog

Increased the delay after finishing song before displaying the results screen from 1 second to 3 seconds to give more time for BG animations.