### PR TITLE
Fix accidental context menu opening in Windows

### DIFF
--- a/bemuse/src/game/game-scene.js
+++ b/bemuse/src/game/game-scene.js
@@ -20,7 +20,7 @@ function showCanvas(display, container) {
   container.addEventListener('touchstart', disableContextMenu)
   function disableContextMenu() {
     container.removeEventListener('touchstart', disableContextMenu)
-    container.addEventListener('contextmenu', e => {
+    container.addEventListener('contextmenu', (e) => {
       e.preventDefault()
     })
   }

--- a/bemuse/src/game/game-scene.js
+++ b/bemuse/src/game/game-scene.js
@@ -17,6 +17,13 @@ function showCanvas(display, container) {
   var { view, wrapper } = display
   var { width, height } = view
   container.appendChild(wrapper)
+  container.addEventListener('touchstart', disableContextMenu)
+  function disableContextMenu() {
+    container.removeEventListener('touchstart', disableContextMenu)
+    container.addEventListener('contextmenu', e => {
+      e.preventDefault()
+    })
+  }
 
   resize()
   $(window).on('resize', resize)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/193136/139539235-06f0644f-8fa0-47a3-a808-83748c741b5e.png)

### Changelog

Fixed a problem on Microsoft Surface devices where holding a note (in Microsoft Edge) or triggering 2 simultaneous notes (in Google Chrome) [triggers a context menu](https://github.com/bemusic/bemuse/pull/737).
