### PR TITLE
Enable auto play when clicking on the chart with Alt key held down

### DIFF
--- a/bemuse/src/app/game-launcher.ts
+++ b/bemuse/src/app/game-launcher.ts
@@ -35,6 +35,7 @@ type LaunchOptions = {
   saveSpeed: (speed: number) => void
   saveLeadTime: (speed: number) => void
   onRagequitted: () => void
+  autoplayEnabled: boolean
 }
 
 export async function launch(launchOptions: LaunchOptions) {
@@ -72,6 +73,7 @@ async function launchGame(
     saveSpeed,
     saveLeadTime,
     onRagequitted,
+    autoplayEnabled,
   }: LaunchOptions,
   sceneDisplayContext: SceneDisplayContext,
   setCurrentWork: (work: string) => void
@@ -119,6 +121,7 @@ async function launchGame(
     tutorial: !!song.tutorial,
     players: [
       {
+        autoplayEnabled: autoplayEnabled,
         speed: autoVelocity.getInitialSpeed(),
         placement: options['player.P1.panel'],
         scratch: scratch,

--- a/bemuse/src/app/io/MusicSelectionIO.js
+++ b/bemuse/src/app/io/MusicSelectionIO.js
@@ -26,7 +26,7 @@ export function selectChart(song, chart) {
   })
 }
 
-export function launchGame(server, song, chart) {
+export function launchGame(server, song, chart, { autoplayEnabled }) {
   return createIO(({ store }, run) => {
     Promise.resolve(
       GameLauncher.launch({
@@ -43,6 +43,7 @@ export function launchGame(server, song, chart) {
         onRagequitted: () => {
           store.dispatch({ type: ReduxState.RAGEQUITTED })
         },
+        autoplayEnabled,
       })
     ).done()
   })

--- a/bemuse/src/app/ui/MusicChartSelectorItem.jsx
+++ b/bemuse/src/app/ui/MusicChartSelectorItem.jsx
@@ -46,8 +46,8 @@ class MusicChartSelectorItem extends React.Component {
       </span>
     )
   }
-  handleClick = () => {
-    this.props.onChartClick(this.props.chart)
+  handleClick = (e) => {
+    this.props.onChartClick(this.props.chart, e)
   }
 }
 

--- a/bemuse/src/app/ui/MusicSelectScene.jsx
+++ b/bemuse/src/app/ui/MusicSelectScene.jsx
@@ -76,11 +76,12 @@ const enhance = compose(
       MusicSearchIO.handleSearchTextType(text),
     onLaunchGame:
       ({ musicSelect }) =>
-      () =>
+      (extraOptions) =>
         MusicSelectionIO.launchGame(
           musicSelect.server,
           musicSelect.song,
-          musicSelect.chart
+          musicSelect.chart,
+          extraOptions
         ),
   })
 )
@@ -290,11 +291,13 @@ class MusicSelectScene extends React.PureComponent {
   handleMusicListTouch = () => {
     this.setState({ inSong: false })
   }
-  handleChartClick = (chart) => {
+  handleChartClick = (chart, e) => {
     if (this.props.musicSelect.chart.md5 === chart.md5) {
       Analytics.send('MusicSelectScene', 'launch game')
       MusicPreviewer.go()
-      this.props.onLaunchGame()
+      this.props.onLaunchGame({
+        autoplayEnabled: e.altKey,
+      })
     } else {
       Analytics.send('MusicSelectScene', 'select chart')
       this.props.onSelectChart(this.props.musicSelect.song, chart)

--- a/bemuse/src/game/display/index.js
+++ b/bemuse/src/game/display/index.js
@@ -37,9 +37,10 @@ export class GameDisplay {
   }
   start() {
     this._started = new Date().getTime()
-    let player = this._game.players[0]
-    let songInfo = player.notechart.songInfo
-    this._stateful['song_title'] = songInfo.title
+    const player = this._game.players[0]
+    const songInfo = player.notechart.songInfo
+    const prefix = player.options.autoplayEnabled ? '[AUTOPLAY] ' : ''
+    this._stateful['song_title'] = prefix + songInfo.title
     this._stateful['song_artist'] = songInfo.artist
     this._duration = player.notechart.duration
   }

--- a/bemuse/src/game/player.ts
+++ b/bemuse/src/game/player.ts
@@ -25,6 +25,7 @@ type PlayerOptionsInputMapping = {
 }
 
 type PlayerOptionsInternal = {
+  autoplayEnabled: boolean
   autosound: boolean
   speed: number
   placement: PlayerOptionsPlacement
@@ -36,6 +37,7 @@ type PlayerOptionsInternal = {
 }
 
 export type PlayerOptionsInput = PlayerOptions & {
+  autoplayEnabled?: boolean
   autosound?: boolean
   speed: number
   placement?: PlayerOptionsPlacement
@@ -54,6 +56,7 @@ export class Player {
     options: PlayerOptionsInput
   ) {
     this.options = {
+      autoplayEnabled: !!options.autoplayEnabled,
       autosound: !!options.autosound,
       speed: +options.speed,
       placement: options.placement || 'center',

--- a/bemuse/src/game/state/player-state.ts
+++ b/bemuse/src/game/state/player-state.ts
@@ -155,6 +155,9 @@ export class PlayerState {
     this.speed += direction * amount
     if (this.speed < 0.2) this.speed = 0.2
   }
+  _shouldAutoplay() {
+    return this.player.options.autoplayEnabled || isAutoplayEnabled()
+  }
   _judgeColumn(buffer: NoteBuffer, control: Control, column: string) {
     let judgedNote
     let judgment
@@ -166,7 +169,7 @@ export class PlayerState {
         let shouldBreak = this.getNoteStatus(note) !== 'active'
         judgedNote = note
         judgment = this._judgeNote(note)
-        if (isAutoplayEnabled()) {
+        if (this._shouldAutoplay()) {
           autoPlayed = true
         }
         if (shouldBreak) break
@@ -225,7 +228,7 @@ export class PlayerState {
   _shouldJudge(note: GameNote, control: Control, buffer: NoteBuffer) {
     let status = this.getNoteStatus(note)
     if (status === 'unjudged') {
-      if (isAutoplayEnabled() && this._gameTime >= note.time) {
+      if (this._shouldAutoplay() && this._gameTime >= note.time) {
         this.tainted = true
         return true
       }
@@ -238,7 +241,7 @@ export class PlayerState {
       return missed || hit
     } else if (status === 'active') {
       const noteEnd = note.end || invariant(false, 'note.end must exist')
-      if (isAutoplayEnabled() && this._gameTime >= noteEnd.time) {
+      if (this._shouldAutoplay() && this._gameTime >= noteEnd.time) {
         this.tainted = true
         return true
       }
@@ -258,7 +261,7 @@ export class PlayerState {
     let result = this._noteResult.get(note)
     let isDown = !result || result.status === 'unjudged'
     let isUp = result && result.status === 'active'
-    if (isAutoplayEnabled() && judgment >= 1) {
+    if (this._shouldAutoplay() && judgment >= 1) {
       judgment = 1
     }
     if (note.end) {


### PR DESCRIPTION
Fixes #410

[Requested](https://twitter.com/Nekokan_Server/status/1454338622602108932) by @Nekokan

### Changelog

**Autoplay mode**: If you hold down Alt key while clicking the chart button to start a game, Bemuse will enter into Autoplay mode where notes will be played automatically. The UI will clearly mark the game as autoplayed both in-game and in the result screen.