### PR TITLE
Implement HD-BGA support for BMS files

### DIFF
--- a/bemuse/config/webpack.js
+++ b/bemuse/config/webpack.js
@@ -6,6 +6,7 @@ import path from './path'
 import webpack from 'webpack'
 import webpackResolve from './webpackResolve'
 import ServiceWorkerWebpackPlugin from 'serviceworker-webpack-plugin'
+import TerserPlugin from 'terser-webpack-plugin'
 
 function generateBaseConfig() {
   let config = {
@@ -44,6 +45,19 @@ function generateBaseConfig() {
         entry: path('src/app/service-worker.js'),
       }),
     ],
+  }
+
+  if (Env.production()) {
+    config.optimization = {
+      minimize: true,
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            format: { semicolons: false },
+          },
+        }),
+      ],
+    }
   }
 
   if (Env.sourceMapsEnabled() && Env.development()) {

--- a/bemuse/package.json
+++ b/bemuse/package.json
@@ -100,6 +100,7 @@
     "web-audio-test-api": "^0.5.2",
     "webpack": "4",
     "webpack-dev-middleware": "^3.4.0",
+    "terser-webpack-plugin": "^4.2.3",
     "webpack-dev-server": "^3.11.2",
     "worker-loader": "^2.0.0",
     "yn": "^1.3.0",

--- a/bemuse/src/app/game-launcher.ts
+++ b/bemuse/src/app/game-launcher.ts
@@ -248,13 +248,20 @@ async function findVideoUrl(song: Song, assets: LoadSpec['assets']) {
     const extensionRegExp = /\.\w+$/
     const replaceExtension = (name: string, ext: string) =>
       name.replace(extensionRegExp, ext)
-    if (/\.(?:mp4|webm)$/.test(song.video_file)) {
-      return await tryToLoad(song.video_file)
+    const filesToTry: string[] = []
+    if (/\.(?:mp4)$/.test(song.video_file)) {
+      filesToTry.push(song.video_file)
+      filesToTry.push(replaceExtension(song.video_file, '.webm'))
+    } else if (/\.(?:webm)$/.test(song.video_file)) {
+      filesToTry.push(song.video_file)
+      filesToTry.push(replaceExtension(song.video_file, '.mp4'))
     } else if (extensionRegExp.test(song.video_file)) {
-      return (
-        (await tryToLoad(replaceExtension(song.video_file, '.webm'))) ||
-        (await tryToLoad(replaceExtension(song.video_file, '.mp4')))
-      )
+      filesToTry.push(replaceExtension(song.video_file, '.mp4'))
+      filesToTry.push(replaceExtension(song.video_file, '.webm'))
+    }
+    for (const name of filesToTry) {
+      const url = await tryToLoad(name)
+      if (url) return url
     }
   }
 }

--- a/bemuse/src/app/game-launcher.ts
+++ b/bemuse/src/app/game-launcher.ts
@@ -249,10 +249,7 @@ async function findVideoUrl(song: Song, assets: LoadSpec['assets']) {
     const replaceExtension = (name: string, ext: string) =>
       name.replace(extensionRegExp, ext)
     const filesToTry: string[] = []
-    if (/\.(?:mp4)$/.test(song.video_file)) {
-      filesToTry.push(song.video_file)
-      filesToTry.push(replaceExtension(song.video_file, '.webm'))
-    } else if (/\.(?:webm)$/.test(song.video_file)) {
+    if (/\.webm$/i.test(song.video_file)) {
       filesToTry.push(song.video_file)
       filesToTry.push(replaceExtension(song.video_file, '.mp4'))
     } else if (extensionRegExp.test(song.video_file)) {

--- a/common/changes/bemuse-indexer/bms-hd-bga_2021-12-20-14-49.json
+++ b/common/changes/bemuse-indexer/bms-hd-bga_2021-12-20-14-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "bemuse-indexer",
+      "comment": "Added initial support for indexing BGA file metadata for BMS files",
+      "type": "major"
+    }
+  ],
+  "packageName": "bemuse-indexer"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -152,6 +152,7 @@ specifiers:
   stack-chain: ^1.3.0
   style-loader: ^0.23.1
   temp: ^0.8.1
+  terser-webpack-plugin: ^4.2.3
   through2: ^2.0.3
   timesynchro: ^1.0.1
   transform-loader: ^0.2.4
@@ -326,6 +327,7 @@ dependencies:
   stack-chain: 1.3.7
   style-loader: 0.23.1
   temp: 0.8.4
+  terser-webpack-plugin: 4.2.3_webpack@4.46.0
   through2: 2.0.5
   timesynchro: 1.0.1
   transform-loader: 0.2.4
@@ -1640,6 +1642,10 @@ packages:
     resolution: {integrity: sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==}
     dev: false
 
+  /@gar/promisify/1.1.2:
+    resolution: {integrity: sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==}
+    dev: false
+
   /@istanbuljs/load-nyc-config/1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -1889,6 +1895,21 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: false
+
+  /@npmcli/fs/1.0.0:
+    resolution: {integrity: sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==}
+    dependencies:
+      '@gar/promisify': 1.1.2
+      semver: 7.3.5
+    dev: false
+
+  /@npmcli/move-file/1.1.2:
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
     dev: false
 
   /@sindresorhus/is/0.7.0:
@@ -3940,6 +3961,30 @@ packages:
       y18n: 4.0.3
     dev: false
 
+  /cacache/15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@npmcli/fs': 1.0.0
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.0
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.1.5
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.1.11
+      unique-filename: 1.1.1
+    dev: false
+
   /cache-base/1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
@@ -4262,6 +4307,11 @@ packages:
 
   /chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: false
+
+  /chownr/2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
     dev: false
 
   /chrome-trace-event/1.0.3:
@@ -7518,6 +7568,13 @@ packages:
       universalify: 2.0.0
     dev: false
 
+  /fs-minipass/2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.5
+    dev: false
+
   /fs-mkdirp-stream/1.0.0:
     resolution: {integrity: sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=}
     engines: {node: '>= 0.10'}
@@ -10179,6 +10236,15 @@ packages:
       string-length: 4.0.2
     dev: false
 
+  /jest-worker/26.6.2:
+    resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/node': 10.17.60
+      merge-stream: 2.0.0
+      supports-color: 7.2.0
+    dev: false
+
   /jest-worker/27.3.1:
     resolution: {integrity: sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==}
     engines: {node: '>= 10.13.0'}
@@ -11552,6 +11618,42 @@ packages:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
     dev: false
 
+  /minipass-collect/1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.5
+    dev: false
+
+  /minipass-flush/1.0.5:
+    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.5
+    dev: false
+
+  /minipass-pipeline/1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      minipass: 3.1.5
+    dev: false
+
+  /minipass/3.1.5:
+    resolution: {integrity: sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==}
+    engines: {node: '>=8'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
+  /minizlib/2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.5
+      yallist: 4.0.0
+    dev: false
+
   /mississippi/3.0.0:
     resolution: {integrity: sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==}
     engines: {node: '>=4.0.0'}
@@ -11594,6 +11696,12 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.5
+    dev: false
+
+  /mkdirp/1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
     dev: false
 
   /mobx-react-lite/1.5.2_mobx@5.15.7+react@16.14.0:
@@ -12451,6 +12559,13 @@ packages:
       p-try: 2.2.0
     dev: false
 
+  /p-limit/3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      yocto-queue: 0.1.0
+    dev: false
+
   /p-locate/2.0.0:
     resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
     engines: {node: '>=4'}
@@ -12487,6 +12602,13 @@ packages:
   /p-map/3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
     engines: {node: '>=8'}
+    dependencies:
+      aggregate-error: 3.1.0
+    dev: false
+
+  /p-map/4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
     dev: false
@@ -14800,6 +14922,12 @@ packages:
       randombytes: 2.1.0
     dev: false
 
+  /serialize-javascript/5.0.1:
+    resolution: {integrity: sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: false
+
   /serve-index/1.9.1:
     resolution: {integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=}
     engines: {node: '>= 0.8.0'}
@@ -15347,6 +15475,13 @@ packages:
     resolution: {integrity: sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==}
     dependencies:
       figgy-pudding: 3.5.2
+    dev: false
+
+  /ssri/8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
+    dependencies:
+      minipass: 3.1.5
     dev: false
 
   /stable/0.1.8:
@@ -15915,6 +16050,18 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
+  /tar/6.1.11:
+    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
+    engines: {node: '>= 10'}
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 3.1.5
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+    dev: false
+
   /tcp-port-used/1.0.2:
     resolution: {integrity: sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==}
     dependencies:
@@ -15983,6 +16130,24 @@ packages:
       worker-farm: 1.7.0
     dev: false
 
+  /terser-webpack-plugin/4.2.3_webpack@4.46.0:
+    resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      cacache: 15.3.0
+      find-cache-dir: 3.3.2
+      jest-worker: 26.6.2
+      p-limit: 3.1.0
+      schema-utils: 3.1.1
+      serialize-javascript: 5.0.1
+      source-map: 0.6.1
+      terser: 5.9.0
+      webpack: 4.46.0
+      webpack-sources: 1.4.3
+    dev: false
+
   /terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
     engines: {node: '>=6.0.0'}
@@ -15990,6 +16155,16 @@ packages:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
+      source-map-support: 0.5.20
+    dev: false
+
+  /terser/5.9.0:
+    resolution: {integrity: sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      source-map: 0.7.3
       source-map-support: 0.5.20
     dev: false
 
@@ -17691,6 +17866,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /yocto-queue/0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+    dev: false
+
   file:projects/bemuse-docs.tgz:
     resolution: {integrity: sha512-Mwwn271uPc9vdDxQ8J174q/Fj597lO5EpCWH229inmNIHcp+9/EO8PbiB4de5LvEnKtUPLjcCxS+I3ZksUux2Q==, tarball: file:projects/bemuse-docs.tgz}
     name: '@rush-temp/bemuse-docs'
@@ -17716,7 +17896,7 @@ packages:
     dev: false
 
   file:projects/bemuse-indexer.tgz:
-    resolution: {integrity: sha512-CNXDgvucbGG5l/f3b3lDtfoDHcx047yXoR6zJX0J0KWdqrao4xnZauiRTAm0LJP2MHP1ZY6FNtv3e46SzC1ciQ==, tarball: file:projects/bemuse-indexer.tgz}
+    resolution: {integrity: sha512-HuEGn4sgurUVfB96yQg5hNYXtuzxb0fL4qBqSM9ksrdhD22dBTZuQDVnueGKBwPgcGOv+MetUxSkL0P6Z5Al5g==, tarball: file:projects/bemuse-indexer.tgz}
     name: '@rush-temp/bemuse-indexer'
     version: 0.0.0
     dependencies:
@@ -17737,7 +17917,7 @@ packages:
     dev: false
 
   file:projects/bemuse-notechart.tgz:
-    resolution: {integrity: sha512-uVzawhxYfUiB2jt4rkmjDyx0XzxPEEyCC7iwrCajELVvZYSWalpjkRl2fuTuL+51PrRx3rnjqRcSF9UFCqhIYg==, tarball: file:projects/bemuse-notechart.tgz}
+    resolution: {integrity: sha512-f1oOj5Izl0ZC5bwx5iEj97dNMOLOxs9DBO3ZLenjJ/SN0JzV6TtzhJITpqW9bYdMoMkUF8A2QobgL0HRPx2rQg==, tarball: file:projects/bemuse-notechart.tgz}
     name: '@rush-temp/bemuse-notechart'
     version: 0.0.0
     dependencies:
@@ -17755,7 +17935,7 @@ packages:
     dev: false
 
   file:projects/bemuse-tools.tgz:
-    resolution: {integrity: sha512-PsQc5INQiHeQjeads+wDycUQKPXARBHqidI4eFDMYwvFM3X2ruDzRjLAwYyrgVvfGHaaFH9qZwcE0QcWDyeQ8Q==, tarball: file:projects/bemuse-tools.tgz}
+    resolution: {integrity: sha512-2tz9yCTTVFIEvFwefWdYPSW8NqVtvtBtQY+89czLifsQSsP2tcUmswzfLaACc6MZ7qCZcFoV3hNzkaME/8QeRg==, tarball: file:projects/bemuse-tools.tgz}
     name: '@rush-temp/bemuse-tools'
     version: 0.0.0
     dependencies:
@@ -17791,7 +17971,7 @@ packages:
     dev: false
 
   file:projects/bemuse.tgz_@types+node@10.17.60:
-    resolution: {integrity: sha512-65tFTeOSRBT48Jgmd4yUUpZByMHEY5nLJbJLMIdnrXJtq5nd3FBvGUQanxH5evc8mSLr+ImQFXkyafGijIf/6w==, tarball: file:projects/bemuse.tgz}
+    resolution: {integrity: sha512-gA+Ci/qICLzBGiDdBf4pgG7iLeX/TXvi/JXDY7UABwbw+SCQVv8STm6wP7s9V4S38hbTA4xkedC47y4rHJ/WJQ==, tarball: file:projects/bemuse.tgz}
     id: file:projects/bemuse.tgz
     name: '@rush-temp/bemuse'
     version: 0.0.0
@@ -17908,6 +18088,7 @@ packages:
       sinon-chai: 3.7.0_chai@4.3.4+sinon@6.3.5
       source-map-support: 0.5.20
       style-loader: 0.23.1
+      terser-webpack-plugin: 4.2.3_webpack@4.46.0
       throat: 2.0.2
       through2: 2.0.5
       timesynchro: 1.0.1
@@ -17975,7 +18156,7 @@ packages:
     dev: false
 
   file:projects/bmson.tgz:
-    resolution: {integrity: sha512-7fhgthm6wZFU1SQVMaM8udevaKgEn57Da7TbgnwYUoOglXA6b+dh5NfLN2hMm3v7uZT51RcuRJz6w4QaP6IJuA==, tarball: file:projects/bmson.tgz}
+    resolution: {integrity: sha512-1Wkiwg0kgy20uGNN9sNN+wmyiMQkdI9iSodQAhMH1dG3bm9RGJ5RRp9JRsVTyNaY5RUhnqD2JUC8XSPOhO1yEQ==, tarball: file:projects/bmson.tgz}
     name: '@rush-temp/bmson'
     version: 0.0.0
     dependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17896,7 +17896,7 @@ packages:
     dev: false
 
   file:projects/bemuse-indexer.tgz:
-    resolution: {integrity: sha512-HuEGn4sgurUVfB96yQg5hNYXtuzxb0fL4qBqSM9ksrdhD22dBTZuQDVnueGKBwPgcGOv+MetUxSkL0P6Z5Al5g==, tarball: file:projects/bemuse-indexer.tgz}
+    resolution: {integrity: sha512-KzQ3RfiCTN7nPjaOSlAywd14j5X1RSTAMBFdeS1mn81ezV0+DtB2bxgLGlIEZqJOXsfertWBU+dzDQLVhdTHEw==, tarball: file:projects/bemuse-indexer.tgz}
     name: '@rush-temp/bemuse-indexer'
     version: 0.0.0
     dependencies:
@@ -17912,6 +17912,7 @@ packages:
       invariant: 2.2.4
       lodash: 4.17.21
       mocha: 5.2.0
+      nyc: 11.9.0
       object-assign: 4.1.1
       typescript: 4.4.4
     dev: false
@@ -17956,6 +17957,7 @@ packages:
       mime: 1.6.0
       mkdirp: 0.5.5
       mocha: 5.2.0
+      nyc: 11.9.0
       rx: 2.5.3
       temp: 0.8.4
       throat: 1.0.0

--- a/packages/bemuse-indexer/package.json
+++ b/packages/bemuse-indexer/package.json
@@ -42,7 +42,8 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.2.0",
-    "typescript": "^4.4.3"
+    "typescript": "^4.4.3",
+    "nyc": "^11.9.0"
   },
   "volta": {
     "extends": "../../volta.json"

--- a/packages/bemuse-indexer/src/bms-bga.ts
+++ b/packages/bemuse-indexer/src/bms-bga.ts
@@ -1,0 +1,27 @@
+import * as BMS from 'bms'
+import { BGAInfo } from './types'
+
+export function getBmsBga(
+  chart: BMS.BMSChart,
+  options: { timing: BMS.Timing }
+): BGAInfo | undefined {
+  const getFile = (object: BMS.BMSObject): string | undefined => {
+    return chart.headers.get('bmp' + object.value)
+  }
+  const bgaObjects = chart.objects
+    .all()
+    .filter((o) => o.channel === '04' && isVideoFile(getFile(o)))
+  if (bgaObjects.length === 0) return undefined
+  const object = bgaObjects[0]
+  const timing = options.timing
+  const beat = chart.measureToBeat(object.measure, object.fraction)
+  const offset = timing.beatToSeconds(beat)
+  const file = getFile(object)
+  if (!file) return undefined
+  return { file, offset }
+}
+
+function isVideoFile(path: string | undefined): boolean {
+  if (!path) return false
+  return /\.(?:mpg|mpeg|avi|wmv|ogv|webm|ogm|mov|mp4|mkv|flv|m4v)$/i.test(path)
+}

--- a/packages/bemuse-indexer/src/index.spec.ts
+++ b/packages/bemuse-indexer/src/index.spec.ts
@@ -117,6 +117,25 @@ describe('getFileInfo (bms)', function () {
       expect(bpm.max).to.equal(240)
     })
   })
+
+  describe('.bga', function () {
+    it('should be undefined for songs without bga', async function () {
+      var source = ['#BPM 120', '#00111:0101'].join('\n')
+      return expect((await info(source)).bga).to.equal(undefined)
+    })
+    it('should exist for songs with bga', async function () {
+      var source = [
+        '#BPM 120',
+        '#BMPBG meow.mpg',
+        '#00111:0101',
+        '#00104:01BG',
+      ].join('\n')
+      return expect((await info(source)).bga).to.deep.equal({
+        file: 'meow.mpg',
+        offset: 3,
+      })
+    })
+  })
 })
 
 describe('getFileInfo (bmson)', function () {

--- a/packages/bemuse-indexer/src/index.ts
+++ b/packages/bemuse-indexer/src/index.ts
@@ -35,6 +35,7 @@ import {
   OutputSongInfo,
   OutputChart,
 } from './types'
+import { getBmsBga } from './bms-bga'
 
 var readBMS = Bluebird.promisify<string, Buffer, ReaderOptions | null>(
   Reader.readAsync
@@ -76,6 +77,7 @@ _extensions['.bms'] = async function (source, meta) {
     timing: timing,
     scratch: hasScratch(chart),
     keys: getKeys(chart),
+    bga: getBmsBga(chart, { timing }),
   }
 }
 


### PR DESCRIPTION
Closes #744 

### Changelog

**HD-BGA support for BMS files.** Bemuse now tries to load BGAs in BMS files when an `.mp4` and `.webm` files are provided.

![bga-support](https://user-images.githubusercontent.com/193136/146781819-969d466b-c7ea-4c3e-9597-93d6bdde7bd9.png)

In prior versions, Bemuse did not support background animation (BGA) video for the BMS format, because most BMS archives at that time comes with low-resolution (256x256) video files. These files commonly use the MPG, AVI, or WMV format, which cannot be played on the web.

In 2016, the bmson project introduced recommendations for high-definition BGAs in bmson files. The [specification recommended BGA files to be in MP4 or WebM format](https://bmson-spec.readthedocs.io/en/master/doc/index.html#bga-bga). These formats can be played on the web and it is supported natively in Bemuse. So since 2016, Bemuse supports BGA for bmson, but not BMS.

In 2018, [beatoraja introduced support for high-definition BGAs in BMS files](https://github.com/exch-bms2/beatoraja/pull/190). BMS authors can put `bga.mp4` and `bga.mpg` files side-by-side and `bga.mp4` file will take precedence over `bga.mpg` even if `bga.mpg` is specified in the BMS file (for backwards-compatibility with LR2).

In 2021, it is now more common for BMS authors to distribute BMS archives with BGA files in both `.mp4` and `.mpg` format. Therefore, Bemuse now follows this behavior by beatoraja.