### PR TITLE
Migrate builds from CircleCI to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,11 @@ jobs:
         
       - name: Setup Node
         uses: actions/setup-node@v3
-        
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-        
-      - name: Setup pnpm cache
-        uses: actions/cache@v3
+
+      - name: Rush Install
+        uses: advancedcsg-open/actions-rush@v1
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          build: true
         
       - name: Install dependencies
         run: node common/scripts/install-run-rush.js install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: '1'
+      TOOL_NODE_FLAGS: --max_old_space_size=4096
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: node common/scripts/install-run-rush.js install
+      - name: Build
+        run: |
+          rm -rf dist
+          node build-scripts build
+      - name: Checks
+        run: node build-scripts pre-deploy
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ jobs:
         
       - name: Setup Node
         uses: actions/setup-node@v3
-
-      - name: Rush Install
-        uses: advancedcsg-open/actions-rush@v1
-        with:
-          build: true
         
       - name: Install dependencies
         run: node common/scripts/install-run-rush.js install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,23 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+        
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: pnpm
+        
       - name: Install dependencies
         run: node common/scripts/install-run-rush.js install
+        
       - name: Build
         run: |
           rm -rf dist
           node build-scripts build
+          
       - name: Checks
         run: node build-scripts pre-deploy
+        
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,21 @@ jobs:
         
       - name: Setup Node
         uses: actions/setup-node@v3
+        
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
         with:
-          cache: pnpm
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
         
       - name: Install dependencies
         run: node common/scripts/install-run-rush.js install
@@ -35,5 +48,6 @@ jobs:
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:
+          name: bemuse-build-${{ github.sha }}
           path: dist
       


### PR DESCRIPTION
This PR implements the build task in GH Actions

Closes #757 

### Changelog

Started migrating the delivery pipeline to be automated with GitHub Actions.